### PR TITLE
STY: Add `isort` and a collection of rules to `ruff`

### DIFF
--- a/heracles/catalog/__init__.py
+++ b/heracles/catalog/__init__.py
@@ -18,7 +18,7 @@
 # License along with Heracles. If not, see <https://www.gnu.org/licenses/>.
 """module for catalogue processing"""
 
-from .base import Catalog, CatalogBase, CatalogView, CatalogPage  # noqa: F401
-from .filters import InvalidValueFilter, FootprintFilter  # noqa: F401
 from .array import ArrayCatalog  # noqa: F401
+from .base import Catalog, CatalogBase, CatalogPage, CatalogView  # noqa: F401
+from .filters import FootprintFilter, InvalidValueFilter  # noqa: F401
 from .fits import FitsCatalog  # noqa: F401

--- a/heracles/catalog/array.py
+++ b/heracles/catalog/array.py
@@ -41,8 +41,7 @@ class ArrayCatalog(CatalogBase):
     def _size(self, selection):
         if selection is None:
             return len(self._arr)
-        else:
-            return len(self._arr[selection])
+        return len(self._arr[selection])
 
     def _join(self, first, *other):
         """join boolean masks"""

--- a/heracles/catalog/base.py
+++ b/heracles/catalog/base.py
@@ -22,6 +22,7 @@ from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Protocol, runtime_checkable
+
 import numpy as np
 
 
@@ -40,7 +41,8 @@ class CatalogPage:
             if size == -1:
                 size = len(rows)
             elif size != len(rows):
-                raise ValueError("inconsistent row length")
+                msg = "inconsistent row length"
+                raise ValueError(msg)
         self._size = size
 
     def __init__(self, data: Mapping) -> None:
@@ -54,8 +56,7 @@ class CatalogPage:
         """Return one or more columns without checking."""
         if isinstance(col, (list, tuple)):
             return tuple(self._data[c] for c in col)
-        else:
-            return self._data[col]
+        return self._data[col]
 
     def __len__(self):
         """Number of columns in the page."""
@@ -90,7 +91,8 @@ class CatalogPage:
         for c in col:
             v = self._data[c]
             if np.any(np.isnan(v)):
-                raise ValueError(f'invalid values in column "{c}"')
+                msg = f'invalid values in column "{c}"'
+                raise ValueError(msg)
             val.append(v)
         if len(val) == 1:
             val = val[0]
@@ -300,12 +302,12 @@ class CatalogBase(metaclass=ABCMeta):
     @property
     def base(self):
         """returns ``None`` since this is not a view of another catalogue"""
-        return None
+        return
 
     @property
     def selection(self):
         """returns ``None`` since this is not a view of another catalogue"""
-        return None
+        return
 
     @property
     def names(self):

--- a/heracles/catalog/filters.py
+++ b/heracles/catalog/filters.py
@@ -19,8 +19,9 @@
 """module for catalogue filters"""
 
 import warnings
-import numpy as np
+
 import healpy as hp
+import numpy as np
 
 
 class InvalidValueFilter:

--- a/heracles/catalog/fits.py
+++ b/heracles/catalog/fits.py
@@ -18,7 +18,8 @@
 # License along with Heracles. If not, see <https://www.gnu.org/licenses/>.
 """module for catalogue processing"""
 
-from weakref import ref, finalize
+from weakref import finalize, ref
+
 import fitsio
 
 from .base import CatalogBase, CatalogPage
@@ -86,7 +87,8 @@ class FitsCatalog(CatalogBase):
                         # find table data extension
                         hdu = next(filter(_is_table_hdu, fits))
                     except StopIteration:
-                        raise TypeError("no table data in FITS") from None
+                        msg = "no table data in FITS"
+                        raise TypeError(msg) from None
                 else:
                     hdu = fits[self._ext]
 

--- a/heracles/covariance.py
+++ b/heracles/covariance.py
@@ -22,8 +22,9 @@ import logging
 import time
 from datetime import timedelta
 from itertools import combinations_with_replacement
-import numpy as np
+
 import healpy as hp
+import numpy as np
 
 from ._kmeans_radec import kmeans_sample
 
@@ -63,7 +64,8 @@ def add_sample(cov, x, y=None):
         y = np.reshape(y, -1)
 
     if x.size != cov.sample_row_mean.size or y.size != cov.sample_col_mean.size:
-        raise ValueError("size mismatch between sample and covariance matrix")
+        msg = "size mismatch between sample and covariance matrix"
+        raise ValueError(msg)
 
     delta = x - cov.sample_row_mean
     cov.sample_count += 1
@@ -83,7 +85,11 @@ def update_covariance(cov, sample):
         if (k1, k2) not in cov:
             nrows, ncols = np.size(v1), np.size(v2)
             logger.info(
-                "creating %d x %d covariance matrix for %s, %s", nrows, ncols, k1, k2
+                "creating %d x %d covariance matrix for %s, %s",
+                nrows,
+                ncols,
+                k1,
+                k2,
             )
             cov[k1, k2] = SampleCovariance(nrows, ncols)
         logger.info("updating covariance for %s, %s", k1, k2)
@@ -97,7 +103,13 @@ def update_covariance(cov, sample):
 
 
 def jackknife_regions_kmeans(
-    fpmap, n, *, maxrepeat=5, maxiter=1000, tol=1e-5, return_centers=False
+    fpmap,
+    n,
+    *,
+    maxrepeat=5,
+    maxiter=1000,
+    tol=1e-5,
+    return_centers=False,
 ):
     """partition a footprint map into n regions using k-means"""
 
@@ -128,11 +140,13 @@ def jackknife_regions_kmeans(
         if km.converged:
             logger.info("k-means converged")
             break
-        else:
-            logger.info("k-means not converged; repeat")
+        logger.info("k-means not converged; repeat")
     else:
-        raise RuntimeError(
+        msg = (
             f"k-means failed to partition map into {n} regions after repeat {maxrepeat}"
+        )
+        raise RuntimeError(
+            msg,
         )
 
     areas = 60**4 // 100 / np.pi / npix * np.bincount(km.labels)

--- a/heracles/io.py
+++ b/heracles/io.py
@@ -18,12 +18,12 @@
 # License along with Heracles. If not, see <https://www.gnu.org/licenses/>.
 """module for file reading and writing"""
 
-import os
 import logging
+import os
 
-import numpy as np
-import healpy as hp
 import fitsio
+import healpy as hp
+import numpy as np
 
 from .util import toc_match
 
@@ -91,7 +91,13 @@ def read_mask(mask_name, nside=None, field=0, extra_mask_name=None):
 
 
 def write_maps(
-    filename, maps, *, clobber=False, workdir=".", include=None, exclude=None
+    filename,
+    maps,
+    *,
+    clobber=False,
+    workdir=".",
+    include=None,
+    exclude=None,
 ):
     """write a set of maps to FITS file
 
@@ -158,16 +164,22 @@ def write_maps(
             nside = hp.npix2nside(npix)
             fits[ext].write_key("PIXTYPE", "HEALPIX", "HEALPIX pixelisation")
             fits[ext].write_key(
-                "ORDERING", "RING", "Pixel ordering scheme, either RING or NESTED"
+                "ORDERING",
+                "RING",
+                "Pixel ordering scheme, either RING or NESTED",
             )
             fits[ext].write_key("NSIDE", nside, "Resolution parameter of HEALPIX")
             fits[ext].write_key("FIRSTPIX", 0, "First pixel # (0 based)")
             fits[ext].write_key("LASTPIX", npix - 1, "Last pixel # (0 based)")
             fits[ext].write_key(
-                "INDXSCHM", "IMPLICIT", "Indexing: IMPLICIT or EXPLICIT"
+                "INDXSCHM",
+                "IMPLICIT",
+                "Indexing: IMPLICIT or EXPLICIT",
             )
             fits[ext].write_key(
-                "OBJECT", "FULLSKY", "Sky coverage, either FULLSKY or PARTIAL"
+                "OBJECT",
+                "FULLSKY",
+                "Sky coverage, either FULLSKY or PARTIAL",
             )
 
             # write the TOC entry
@@ -224,7 +236,13 @@ def read_maps(filename, workdir=".", *, include=None, exclude=None):
 
 
 def write_alms(
-    filename, alms, *, clobber=False, workdir=".", include=None, exclude=None
+    filename,
+    alms,
+    *,
+    clobber=False,
+    workdir=".",
+    include=None,
+    exclude=None,
 ):
     """write a set of alms to FITS file
 

--- a/heracles/plot.py
+++ b/heracles/plot.py
@@ -21,10 +21,10 @@
 from collections import defaultdict
 from collections.abc import Mapping
 from itertools import chain, count, cycle
-import numpy as np
-import matplotlib.pyplot as plt
-from cycler import cycler
 
+import matplotlib.pyplot as plt
+import numpy as np
+from cycler import cycler
 
 DEFAULT_CYCLER = cycler(linestyle=["-", "--", ":", "-."])
 
@@ -64,7 +64,8 @@ def postage_stamps(
         cycler = DEFAULT_CYCLER
 
     if plot is None and transpose is None:
-        raise ValueError("missing plot data")
+        msg = "missing plot data"
+        raise ValueError(msg)
 
     if isinstance(plot, Mapping):
         plot = [plot]
@@ -81,7 +82,7 @@ def postage_stamps(
         trkeys = {}
 
     stamps = sorted(
-        set(key[-2:] for key in keys) | set(key[-2:][::-1] for key in trkeys)
+        set(key[-2:] for key in keys) | set(key[-2:][::-1] for key in trkeys),
     )
 
     sx = list(set(i for i, _ in stamps))
@@ -220,12 +221,18 @@ def postage_stamps(
 
         ax.set_xlim(xmin, xmax)
         ax.set_xscale(
-            "symlog", linthresh=10, linscale=0.45, subs=[2, 3, 4, 5, 6, 7, 8, 9]
+            "symlog",
+            linthresh=10,
+            linscale=0.45,
+            subs=[2, 3, 4, 5, 6, 7, 8, 9],
         )
 
         ax.set_ylim(ymin_, ymax_)
         ax.set_yscale(
-            "symlog", linthresh=ylin_, linscale=0.45, subs=[2, 3, 4, 5, 6, 7, 8, 9]
+            "symlog",
+            linthresh=ylin_,
+            linscale=0.45,
+            subs=[2, 3, 4, 5, 6, 7, 8, 9],
         )
 
         for tick in ax.xaxis.get_major_ticks():

--- a/heracles/twopoint.py
+++ b/heracles/twopoint.py
@@ -21,16 +21,20 @@
 import logging
 import time
 from datetime import timedelta
-from itertools import product, combinations_with_replacement
+from itertools import combinations_with_replacement, product
 
-import numpy as np
 import healpy as hp
+import numpy as np
 from convolvecl import mixmat, mixmat_eb
 
 from .maps import (
-    update_metadata,
     map_catalogs as _map_catalogs,
+)
+from .maps import (
     transform_maps as _transform_maps,
+)
+from .maps import (
+    update_metadata,
 )
 from .util import toc_match
 
@@ -103,7 +107,9 @@ def angular_power_spectra(alms, alms2=None, *, lmax=None, include=None, exclude=
         twopoint_names.add((k1, k2))
 
     logger.info(
-        "computed %d cl(s) in %s", len(cls), timedelta(seconds=(time.monotonic() - t))
+        "computed %d cl(s) in %s",
+        len(cls),
+        timedelta(seconds=(time.monotonic() - t)),
     )
 
     # return the toc dict of cls
@@ -149,7 +155,9 @@ def debias_cls(cls, noisebias=None, *, inplace=False):
         out[key] = cl
 
     logger.info(
-        "debiased %d cl(s) in %s", len(out), timedelta(seconds=(time.monotonic() - t))
+        "debiased %d cl(s) in %s",
+        len(out),
+        timedelta(seconds=(time.monotonic() - t)),
     )
 
     # return the toc dict of debiased cls
@@ -213,7 +221,8 @@ def depixelate_cls(cls, *, inplace=False):
                     )
                 a = hp.nside2pixarea(nside)
             else:
-                raise ValueError(f"unknown kernel: {kernel}")
+                msg = f"unknown kernel: {kernel}"
+                raise ValueError(msg)
             if fl is not None:
                 cl[lmin:] /= fl[lmin:]
             areas.append(a)
@@ -265,7 +274,11 @@ def mixing_matrices(cls, *, l1max=None, l2max=None, l3max=None):
         elif k1 == "W" and k2 == "W":
             logger.info("computing ++, --, +- mixing matrices for bins %s, %s", i1, i2)
             wpp, wmm, wpm = mixmat_eb(
-                cl, l1max=l1max, l2max=l2max, l3max=l3max, spin=(2, 2)
+                cl,
+                l1max=l1max,
+                l2max=l2max,
+                l3max=l3max,
+                spin=(2, 2),
             )
             mms["++", i1, i2] = wpp
             mms["--", i1, i2] = wmm
@@ -282,7 +295,9 @@ def mixing_matrices(cls, *, l1max=None, l2max=None, l3max=None):
             mms[f"{k1}{k2}", i1, i2] = w
 
     logger.info(
-        "computed %d mm(s) in %s", len(mms), timedelta(seconds=(time.monotonic() - t))
+        "computed %d mm(s) in %s",
+        len(mms),
+        timedelta(seconds=(time.monotonic() - t)),
     )
 
     # return the toc dict of mixing matrices
@@ -338,7 +353,9 @@ def pixelate_mms_healpix(mms, nside, *, inplace=False):
         out[key] = mm
 
     logger.info(
-        "pixelated %d mm(s) in %s", len(out), timedelta(seconds=(time.monotonic() - t))
+        "pixelated %d mm(s) in %s",
+        len(out),
+        timedelta(seconds=(time.monotonic() - t)),
     )
 
     # return the toc dict of modified cls
@@ -368,7 +385,8 @@ def binned_cls(cls, bins, *, weights=None, out=None):
             elif weights == "2l+1":
                 w = 2 * ell + 1
             else:
-                raise ValueError(f"unknown weights string: {weights}")
+                msg = f"unknown weights string: {weights}"
+                raise ValueError(msg)
         else:
             w = weights[: len(cl)]
 

--- a/heracles/util.py
+++ b/heracles/util.py
@@ -18,11 +18,11 @@
 # License along with Heracles. If not, see <https://www.gnu.org/licenses/>.
 """module for utilities"""
 
-import sys
 import os
+import sys
 import time
+from collections.abc import Mapping, Sequence
 from datetime import timedelta
-from collections.abc import Sequence, Mapping
 
 
 def toc_match(key, include=None, exclude=None):
@@ -44,10 +44,10 @@ def toc_filter(obj, include=None, exclude=None):
     """return a filtered toc dict ``d``"""
     if isinstance(obj, Sequence):
         return [toc_filter(item, include, exclude) for item in obj]
-    elif isinstance(obj, Mapping):
+    if isinstance(obj, Mapping):
         return {k: v for k, v in obj.items() if toc_match(k, include, exclude)}
-    else:
-        raise TypeError("invalid input type")
+    msg = "invalid input type"
+    raise TypeError(msg)
 
 
 class Progress:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,47 @@ force-exclude = """
 build.hooks.vcs.version-file = "heracles/_version.py"
 version.source = "vcs"
 
+[tool.ruff]
+extend-exclude = ["heracles/_kmeans_radec.py"]
+fix = true
+force-exclude = true
+line-length = 100
+per-file-ignores = {"test_*" = [
+    "S101",
+]}
+select = [
+    "A",
+    "BLE",
+    "COM",
+    "DJ",
+    "DTZ",
+    "E",
+    "EM",
+    "ERA",
+    "EXE",
+    "F",
+    "I",
+    "ICN",
+    "INP",
+    "ISC",
+    "PD",
+    "PIE",
+    "PYI",
+    "Q",
+    "RET",
+    "RSE",
+    "TCH",
+    "TID",
+    "UP",
+    "W",
+    "YTT",
+]
+target-version = "py38"
+isort.known-first-party = [
+    "heracles",
+]
+mccabe.max-complexity = 18
+
 [tool.tomlsort]
 all = true
 spaces_indent_inline_array = 4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import warnings
 from contextlib import contextmanager
+
 import pytest
 from numba import config
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,6 +1,6 @@
-import pytest
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 
 @pytest.fixture
@@ -300,8 +300,9 @@ def test_invalid_value_filter(catalog):
 
 
 def test_footprint_filter(catalog):
-    from heracles.catalog import FootprintFilter
     from healpy import ang2pix
+
+    from heracles.catalog import FootprintFilter
 
     # footprint for northern hemisphere
     nside = 8
@@ -310,7 +311,7 @@ def test_footprint_filter(catalog):
     # replace x and y in catalog with lon and lat
     catalog.DATA["x"] = lon = np.random.uniform(-180, 180, size=catalog.SIZE)
     catalog.DATA["y"] = lat = np.degrees(
-        np.arcsin(np.random.uniform(-1, 1, size=catalog.SIZE))
+        np.arcsin(np.random.uniform(-1, 1, size=catalog.SIZE)),
     )
 
     filt = FootprintFilter(m, "x", "y")
@@ -373,6 +374,7 @@ def test_array_catalog():
 
 def test_fits_catalog(tmp_path):
     import fitsio
+
     from heracles.catalog import Catalog
     from heracles.catalog.fits import FitsCatalog
 
@@ -436,7 +438,9 @@ def test_fits_catalog(tmp_path):
 
 def test_fits_catalog_caching(tmp_path):
     import gc
+
     import fitsio
+
     from heracles.catalog.fits import FitsCatalog
 
     size = 100

--- a/tests/test_covariance.py
+++ b/tests/test_covariance.py
@@ -55,6 +55,7 @@ def test_sample_covariance():
 
 def test_update_covariance():
     from itertools import combinations_with_replacement
+
     from heracles.covariance import update_covariance
 
     n = 4

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,13 +1,11 @@
 import pytest
 
-
 NFIELDS_TEST = 4
 
 
 @pytest.fixture
 def zbins():
-    zbins = {0: (0.0, 0.8), 1: (1.0, 1.2)}
-    return zbins
+    return {0: (0.0, 0.8), 1: (1.0, 1.2)}
 
 
 @pytest.fixture
@@ -64,26 +62,24 @@ def mock_cls():
 
 @pytest.fixture(scope="session")
 def nside():
-    nside = 32
-    return nside
+    return 32
 
 
 @pytest.fixture(scope="session")
 def datadir(tmp_path_factory):
-    datadir = tmp_path_factory.mktemp("data")
-    return datadir
+    return tmp_path_factory.mktemp("data")
 
 
 @pytest.fixture(scope="session")
 def mock_mask_fields(nside):
-    import numpy as np
     import healpy as hp
+    import numpy as np
 
     npix = hp.nside2npix(nside)
     maps = np.random.rand(npix * NFIELDS_TEST).reshape((npix, NFIELDS_TEST))
     pixels = np.unique(np.random.randint(0, npix, npix // 3))
     maskpix = np.delete(np.arange(0, npix), pixels)
-    for i in range(0, NFIELDS_TEST):
+    for i in range(NFIELDS_TEST):
         maps[:, i][maskpix] = 0
     return [maps, pixels]
 
@@ -146,8 +142,8 @@ def mock_writemask_full(mock_mask_fields, nside, datadir):
 
 @pytest.fixture(scope="session")
 def mock_mask_extra(nside):
-    import numpy as np
     import healpy as hp
+    import numpy as np
 
     npix = hp.nside2npix(nside)
     maps = np.random.rand(npix)
@@ -183,9 +179,10 @@ def mock_writemask_extra(mock_mask_extra, nside, datadir):
 
 
 def test_write_read_maps(tmp_path):
-    import numpy as np
     import healpy as hp
-    from heracles.io import write_maps, read_maps
+    import numpy as np
+
+    from heracles.io import read_maps, write_maps
 
     nside = 4
     npix = 12 * nside**2
@@ -220,7 +217,8 @@ def test_write_read_maps(tmp_path):
 
 def test_write_read_alms(mock_alms, tmp_path):
     import numpy as np
-    from heracles.io import write_alms, read_alms
+
+    from heracles.io import read_alms, write_alms
 
     write_alms("alms.fits", mock_alms, workdir=str(tmp_path))
     assert (tmp_path / "alms.fits").exists()
@@ -233,9 +231,9 @@ def test_write_read_alms(mock_alms, tmp_path):
 
 
 def test_write_read_cls(mock_cls, tmp_path):
-    from heracles.io import write_cls, read_cls
-
     import numpy as np
+
+    from heracles.io import read_cls, write_cls
 
     filename = "test.fits"
     workdir = str(tmp_path)
@@ -257,9 +255,9 @@ def test_write_read_cls(mock_cls, tmp_path):
 
 
 def test_write_read_mms(tmp_path):
-    from heracles.io import write_mms, read_mms
-
     import numpy as np
+
+    from heracles.io import read_mms, write_mms
 
     filename = "test.fits"
     workdir = str(tmp_path)
@@ -283,8 +281,10 @@ def test_write_read_mms(tmp_path):
 
 def test_write_read_cov(mock_cls, tmp_path):
     from itertools import combinations_with_replacement
+
     import numpy as np
-    from heracles.io import write_cov, read_cov
+
+    from heracles.io import read_cov, write_cov
 
     workdir = str(tmp_path)
 
@@ -307,8 +307,9 @@ def test_write_read_cov(mock_cls, tmp_path):
 
 
 def test_read_mask_partial(mock_mask_fields, mock_writemask_partial, nside):
-    from heracles.io import read_mask
     import healpy as hp
+
+    from heracles.io import read_mask
 
     maps = mock_mask_fields[0]
 
@@ -326,8 +327,9 @@ def test_read_mask_partial(mock_mask_fields, mock_writemask_partial, nside):
 
 
 def test_read_mask_full(mock_mask_fields, mock_writemask_full, nside):
-    from heracles.io import read_mask
     import healpy as hp
+
+    from heracles.io import read_mask
 
     maps = mock_mask_fields[0]
 
@@ -350,7 +352,11 @@ def test_read_mask_full(mock_mask_fields, mock_writemask_full, nside):
 
 
 def test_read_mask_extra(
-    mock_mask_fields, mock_mask_extra, mock_writemask_full, nside, mock_writemask_extra
+    mock_mask_fields,
+    mock_mask_extra,
+    mock_writemask_full,
+    nside,
+    mock_writemask_extra,
 ):
     from heracles.io import read_mask
 

--- a/tests/test_kmeans_radec.py
+++ b/tests/test_kmeans_radec.py
@@ -1,5 +1,6 @@
 def test_kmeans_sample():
     import numpy as np
+
     from heracles._kmeans_radec import kmeans_sample
 
     npts = 10000

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -1,5 +1,5 @@
-import numpy as np
 import healpy as hp
+import numpy as np
 import pytest
 
 from .conftest import warns
@@ -15,7 +15,8 @@ def map_catalog(m, catalog):
     except StopIteration as stop:
         return stop.value
     else:
-        raise RuntimeError("generator did not stop")
+        msg = "generator did not stop"
+        raise RuntimeError(msg)
 
 
 @pytest.fixture
@@ -39,7 +40,7 @@ def page(nside):
 
     ipix = np.ravel(
         4 * hp.ring2nest(nside, np.arange(12 * nside**2))[:, np.newaxis]
-        + [0, 1, 2, 3]
+        + [0, 1, 2, 3],
     )
 
     ra, dec = hp.pix2ang(nside * 2, ipix, nest=True, lonlat=True)
@@ -58,8 +59,7 @@ def page(nside):
     def get(*names):
         if len(names) == 1:
             return cols[names[0]]
-        else:
-            return [cols[name] for name in names]
+        return [cols[name] for name in names]
 
     page = Mock()
     page.size = size
@@ -82,6 +82,7 @@ def catalog(page):
 
 def test_visibility_map(nside, vmap):
     from unittest.mock import Mock
+
     from heracles.maps import VisibilityMap
 
     fsky = vmap.mean()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,6 +1,6 @@
 def test_postage_stamps():
-    import numpy as np
     import matplotlib.pyplot as plt
+    import numpy as np
 
     from heracles.plot import postage_stamps
 

--- a/tests/test_twopoint.py
+++ b/tests/test_twopoint.py
@@ -1,6 +1,7 @@
 import unittest.mock
-import pytest
+
 import numpy as np
+import pytest
 
 
 @pytest.fixture
@@ -10,8 +11,7 @@ def nside():
 
 @pytest.fixture
 def zbins():
-    zbins = {0: (0.0, 0.8), 1: (1.0, 1.2)}
-    return zbins
+    return {0: (0.0, 0.8), 1: (1.0, 1.2)}
 
 
 @pytest.fixture
@@ -36,6 +36,7 @@ def mock_alms(zbins):
 
 def test_angular_power_spectra(mock_alms):
     from itertools import combinations_with_replacement
+
     from heracles.twopoint import angular_power_spectra
 
     # alms cross themselves
@@ -58,7 +59,8 @@ def test_angular_power_spectra(mock_alms):
     # explicit include
 
     cls = angular_power_spectra(
-        mock_alms, include=[("P", "P", ..., ...), ("P", "G_E", ..., ...)]
+        mock_alms,
+        include=[("P", "P", ..., ...), ("P", "G_E", ..., ...)],
     )
 
     assert cls.keys() == {
@@ -78,7 +80,8 @@ def test_angular_power_spectra(mock_alms):
     # explicit exclude
 
     cls = angular_power_spectra(
-        mock_alms, exclude=[("P", "P"), ("P", "G_E"), ("P", "G_B")]
+        mock_alms,
+        exclude=[("P", "P"), ("P", "G_E"), ("P", "G_B")],
     )
 
     assert cls.keys() == {
@@ -148,6 +151,7 @@ def test_mixing_matrices():
 
 def test_pixelate_mms_healpix():
     import healpy as hp
+
     from heracles.twopoint import pixelate_mms_healpix
 
     nside = 512

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -39,6 +39,7 @@ def test_toc_filter():
 
 def test_progress():
     from io import StringIO
+
     from heracles.util import Progress
 
     f = StringIO()


### PR DESCRIPTION
Adds [isort](https://pycqa.github.io/isort) which sorts your imports alphabetically, and can be configured into sections if desired. As well as adding some more [rules to ruff](https://beta.ruff.rs/docs/rules). We can add more in the future if desired. I've just added those that the code is compatible with for now (with minor changes).

To be merged after #11.

Reviewed-by: @ntessore
