### PR TITLE
DEV: write permission for PR review action

### DIFF
--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -10,6 +10,8 @@ jobs:
     name: Approved
     if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Add Reviewed-By
         uses: ntessore/add-reviewed-by-action@v1


### PR DESCRIPTION
Add the `pull-requests: write` permission to the `pull_request_review` action.

Reviewed-by: @paddyroddy
