### PR TITLE
BUG(maps): errors when catalogue pages are empty

### DIFF
--- a/heracles/catalog/base.py
+++ b/heracles/catalog/base.py
@@ -358,5 +358,5 @@ class CatalogBase(metaclass=ABCMeta):
             for filt in self._filters:
                 filt(page)
 
-            # yield the filtered page, unless empty
+            # yield the filtered page
             yield page


### PR DESCRIPTION
This change skips over empty catalogue pages, which can throw off the averaging.

Reviewed-by: Krishna Naidoo <krishna.naidoo.11@ucl.ac.uk>
