### PR TITLE
ENH(catalog,maps): specify sign of columns at map definition

### DIFF
--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -459,7 +459,7 @@
     "* A position map (P) for angular clustering and galaxy-galaxy lensing;\n",
     "* A shear map (G) for cosmic shear and galaxy-galaxy lensing.\n",
     "\n",
-    "We set that the shear maps should flip the sign of the \"G2\" column (`conjugate=True`)."
+    "We set that the shear maps should flip the sign of the \"G2\" column."
    ]
   },
   {
@@ -473,7 +473,7 @@
     "\n",
     "maps = {\n",
     "    'P': PositionMap(nside, *lonlat),\n",
-    "    'G': ShearMap(nside, *lonlat, 'G1', 'G2', 'WEIGHT', conjugate=True),\n",
+    "    'G': ShearMap(nside, *lonlat, 'G1', '-G2', 'WEIGHT'),\n",
     "}"
    ]
   },

--- a/heracles/catalog/base.py
+++ b/heracles/catalog/base.py
@@ -52,11 +52,20 @@ class CatalogPage:
             v.flags.writeable = False
         self._update()
 
+    def _getdata(self, key):
+        """
+        Return data for one single column.  Supports negating columns
+        (``-COLUMN``), possibly more in the future.
+        """
+        if key[:1] == "-":
+            return -self._data[key[1:]]
+        return self._data[key]
+
     def __getitem__(self, col):
         """Return one or more columns without checking."""
         if isinstance(col, (list, tuple)):
-            return tuple(self._data[c] for c in col)
-        return self._data[col]
+            return tuple(self._getdata(c) for c in col)
+        return self._getdata(col)
 
     def __len__(self):
         """Number of columns in the page."""
@@ -89,7 +98,7 @@ class CatalogPage:
         """Return one or more columns with checking."""
         val = []
         for c in col:
-            v = self._data[c]
+            v = self._getdata(c)
             if np.any(np.isnan(v)):
                 msg = f'invalid values in column "{c}"'
                 raise ValueError(msg)

--- a/heracles/maps.py
+++ b/heracles/maps.py
@@ -455,9 +455,6 @@ class ComplexMap(HealpixMap, NormalizableMap, RandomizableMap):
     Complex maps can have non-zero spin weight, set using the ``spin=``
     parameter.
 
-    Can optionally flip the sign of the second shear component,
-    depending on the ``conjugate`` property.
-
     """
 
     def __init__(
@@ -470,7 +467,6 @@ class ComplexMap(HealpixMap, NormalizableMap, RandomizableMap):
         weight: t.Optional[str] = None,
         *,
         spin: int = 0,
-        conjugate: bool = False,
         normalize: bool = True,
         randomize: bool = False,
         rng: t.Optional[np.random.Generator] = None,
@@ -478,7 +474,6 @@ class ComplexMap(HealpixMap, NormalizableMap, RandomizableMap):
         """Create a new shear map."""
 
         self._spin: int = spin
-        self._conjugate: bool = conjugate
         super().__init__(
             columns=(lon, lat, real, imag, weight),
             nside=nside,
@@ -497,16 +492,6 @@ class ComplexMap(HealpixMap, NormalizableMap, RandomizableMap):
         """Set the spin weight."""
         self._spin = spin
 
-    @property
-    def conjugate(self) -> bool:
-        """Flag to conjugate shear maps."""
-        return self._conjugate
-
-    @conjugate.setter
-    def conjugate(self, conjugate: bool) -> None:
-        """Set the conjugate flag."""
-        self._conjugate = conjugate
-
     def __call__(self, catalog: "Catalog") -> MapGenerator:
         """Map shears from catalogue to HEALPix map."""
 
@@ -514,7 +499,6 @@ class ComplexMap(HealpixMap, NormalizableMap, RandomizableMap):
         *col, wcol = self.columns
 
         # get the map properties
-        conjugate = self.conjugate
         randomize = self.randomize
 
         # number of pixels for nside
@@ -543,9 +527,6 @@ class ComplexMap(HealpixMap, NormalizableMap, RandomizableMap):
                 w = np.ones(page.size)
             else:
                 w = page.get(wcol)
-
-            if conjugate:
-                im = -im
 
             if randomize:
                 a = self.rng.uniform(0.0, 2 * np.pi, size=page.size)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -43,8 +43,8 @@ def catalog(rng):
 def test_catalog_page():
     from heracles.catalog import CatalogPage
 
-    a = [1.0, 2.0, 3.0, 4.0]
-    b = [5.0, 6.0, 7.0, 8.0]
+    a = np.array([1.0, 2.0, 3.0, 4.0])
+    b = np.array([5.0, 6.0, 7.0, 8.0])
 
     page = CatalogPage({"a": a, "b": b})
 
@@ -54,6 +54,7 @@ def test_catalog_page():
     npt.assert_array_equal(page["b"], b)
     npt.assert_array_equal(page["a", "b"], [a, b])
     npt.assert_array_equal(page[["a", "b"]], [a, b])
+    npt.assert_array_equal(page[["a", "-b"]], [a, -b])
 
     # test names attribute
     assert page.names == ["a", "b"]


### PR DESCRIPTION
Replaces the `conjugate=` parameter of `ComplexMap` with the ability to specify the sign of each column directly, in the form `"-COLUMN"`.