### PR TITLE
ENH(catalog,io): move slow healpy import into functions

### DIFF
--- a/heracles/catalog/filters.py
+++ b/heracles/catalog/filters.py
@@ -20,7 +20,6 @@
 
 import warnings
 
-import healpy as hp
 import numpy as np
 
 
@@ -65,8 +64,10 @@ class FootprintFilter:
 
     def __init__(self, footprint, lon, lat):
         """Filter using the given footprint map and position columns."""
+        from healpy import get_nside
+
         self._footprint = footprint
-        self._nside = hp.get_nside(footprint)
+        self._nside = get_nside(footprint)
         self._lonlat = (lon, lat)
 
     @property
@@ -87,7 +88,9 @@ class FootprintFilter:
     def __call__(self, page):
         """filter catalog page"""
 
+        from healpy import ang2pix
+
         lon, lat = self._lonlat
-        ipix = hp.ang2pix(self._nside, page[lon], page[lat], lonlat=True)
+        ipix = ang2pix(self._nside, page[lon], page[lat], lonlat=True)
         exclude = np.where(self._footprint[ipix] == 0)[0]
         page.delete(exclude)

--- a/heracles/io.py
+++ b/heracles/io.py
@@ -28,7 +28,6 @@ from warnings import warn
 from weakref import WeakValueDictionary
 
 import fitsio
-import healpy as hp
 import numpy as np
 
 from .core import TocDict, toc_match
@@ -75,6 +74,8 @@ def _read_metadata(hdu):
 
 def _write_map(fits, ext, m, *, names=None):
     """write HEALPix map to FITS table"""
+
+    import healpy as hp
 
     # prepare column data and names
     cols = list(np.atleast_2d(m))
@@ -199,6 +200,9 @@ def _read_twopoint(fits, ext):
 
 def read_vmap(filename, nside=None, field=0):
     """read visibility map from a HEALPix map file"""
+
+    import healpy as hp
+
     vmap = hp.read_map(filename, field=field, dtype=float)
 
     # set unseen pixels to zero


### PR DESCRIPTION
Move `import healpy` statements from the top of modules into functions where `healpy` functionality is not central.

This speeds up importing these modules massively (several seconds).

Closes: #60