### PR TITLE
TST: remove unnecessary test fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,28 +1,8 @@
-import warnings
-from contextlib import contextmanager
-
 import numpy as np
 import pytest
 from numba import config
 
 config.DISABLE_JIT = True
-
-
-@contextmanager
-def warns(*types):
-    if types == (None,):
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            try:
-                yield
-            finally:
-                pass
-    else:
-        with pytest.warns(*types):
-            try:
-                yield
-            finally:
-                pass
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -2,8 +2,6 @@ import healpy as hp
 import numpy as np
 import pytest
 
-from .conftest import warns
-
 
 def map_catalog(m, catalog):
     g = m(catalog)
@@ -82,6 +80,7 @@ def catalog(page):
 
 
 def test_visibility_map(nside, vmap):
+    from contextlib import nullcontext
     from unittest.mock import Mock
 
     from heracles.maps import VisibilityMap
@@ -94,7 +93,7 @@ def test_visibility_map(nside, vmap):
 
         mapper = VisibilityMap(nside_out)
 
-        with warns(UserWarning if nside != nside_out else None):
+        with pytest.warns(UserWarning) if nside != nside_out else nullcontext():
             result = mapper(catalog)
 
         assert result is not vmap


### PR DESCRIPTION
The custom `warns` fixture is no longer necessary.