### PR TITLE
BUG: fix bad key swap in angular_power_spectra(alms, alms2)

### DIFF
--- a/heracles/twopoint.py
+++ b/heracles/twopoint.py
@@ -100,9 +100,10 @@ def angular_power_spectra(
 
         # retrieve alms from keys; make sure swap is respected
         # this is done only now because alms might lazy-load from file
-        alm1, alm2 = alms[k1, i1], alms2[k2, i2]
         if swapped:
-            alm1, alm2 = alm2, alm1
+            alm1, alm2 = alms2[k1, i1], alms[k2, i2]
+        else:
+            alm1, alm2 = alms[k1, i1], alms2[k2, i2]
 
         # compute the raw cl from the alms
         cl = hp.alm2cl(alm1, alm2, lmax_out=lmax)

--- a/tests/test_twopoint.py
+++ b/tests/test_twopoint.py
@@ -94,6 +94,23 @@ def test_angular_power_spectra(mock_alms):
 
     assert cls.keys() == {(k1, k2, i1, i2) for k1, k2, i1, i2 in comb if i1 != 1}
 
+    # explicit cross with separate alms
+
+    mock_alms1 = {(k, i): alm for (k, i), alm in mock_alms.items() if i % 2 == 0}
+    mock_alms2 = {(k, i): alm for (k, i), alm in mock_alms.items() if i % 2 == 1}
+
+    order = ["P", "G_E", "G_B"]
+
+    comb12 = {
+        (k1, k2, i1, i2) if order.index(k1) <= order.index(k2) else (k2, k1, i2, i1)
+        for k1, i1 in mock_alms1.keys()
+        for k2, i2 in mock_alms2.keys()
+    }
+
+    cls = angular_power_spectra(mock_alms1, mock_alms2)
+
+    assert cls.keys() == comb12
+
 
 def test_debias_cls():
     from heracles.twopoint import debias_cls


### PR DESCRIPTION
Fixes `KeyError` when keys are swapped in `angular_power_spectra()` and `alms2` are given.

Closes: #73