### PR TITLE
API(maps): spherical harmonic transforms from mappers

### DIFF
--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -520,7 +520,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2b4e7378bbce4d9aad245cc95935bdc1",
+       "model_id": "b9e7f4072a8349bfbe5a45433b429037",
        "version_major": 2,
        "version_minor": 0
       },
@@ -690,7 +690,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "44ae51e18b0444cc917716e2eff2569e",
+       "model_id": "86b6b81c8732497c824cf663f0f24a6b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -726,7 +726,7 @@
     }
    ],
    "source": [
-    "alms = transform_maps(maps, lmax=lmax, use_pixel_weights=True, progress=True)"
+    "alms = transform_maps(mapper, maps, lmax=lmax, progress=True)"
    ]
   },
   {
@@ -923,7 +923,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cc2eb3fd9fe5451f87bb5129d9ced2cc",
+       "model_id": "28f4e1aa37f046d98d38751faf16fcac",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1027,7 +1027,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "662e8b4142e34c27ad62d2b88a795240",
+       "model_id": "efab2494bdf444119ce4f008cf2232bb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1063,8 +1063,7 @@
     }
    ],
    "source": [
-    "alms_mm = transform_maps(maps_mm, progress=True,\n",
-    "                         lmax=lmax_mm, use_pixel_weights=True)"
+    "alms_mm = transform_maps(mapper_mm, maps_mm, progress=True, lmax=lmax_mm)"
    ]
   },
   {

--- a/heracles/fields.py
+++ b/heracles/fields.py
@@ -196,7 +196,7 @@ class Positions(Field):
         # map catalogue data asynchronously
         async for page in _pages(catalog, progress):
             lon, lat = page.get(*col)
-            mapper(lon, lat, [pos])
+            mapper.map_values(lon, lat, [pos])
 
             ngal += page.size
 
@@ -300,7 +300,7 @@ class ScalarField(Field):
                 lon, lat, v = page.get(*col)
                 w = page.get(wcol) if wcol is not None else None
 
-                mapper(lon, lat, [val], [v], w)
+                mapper.map_values(lon, lat, [val], [v], w)
 
                 ngal += page.size
                 if w is None:
@@ -391,7 +391,7 @@ class ComplexField(Field):
 
                 w = page.get(wcol) if wcol is not None else None
 
-                mapper(lon, lat, [val[0], val[1]], [re, im], w)
+                mapper.map_values(lon, lat, [val[0], val[1]], [re, im], w)
 
                 ngal += page.size
                 if w is None:
@@ -509,7 +509,7 @@ class Weights(Field):
             else:
                 w = page.get(wcol)
 
-            mapper(lon, lat, [wht], None, w)
+            mapper.map_values(lon, lat, [wht], None, w)
 
             del page, lon, lat, w
 

--- a/heracles/maps/_mapper.py
+++ b/heracles/maps/_mapper.py
@@ -105,7 +105,7 @@ class Mapper(metaclass=MapperMeta):
         """
 
     @abstractmethod
-    def __call__(
+    def map_values(
         self,
         lon: ArrayLike,
         lat: ArrayLike,
@@ -115,4 +115,14 @@ class Mapper(metaclass=MapperMeta):
     ) -> None:
         """
         Add values to maps.
+        """
+
+    @abstractmethod
+    def transform(
+        self,
+        maps: ArrayLike,
+        lmax: int | None = None,
+    ) -> ArrayLike | tuple[ArrayLike, ArrayLike]:
+        """
+        The spherical harmonic transform for this mapper.
         """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,15 +38,31 @@ def test_toc_filter():
         toc_filter(object())
 
 
-def test_toc_nearest():
-    from heracles.core import toc_nearest
+def test_multi_value_getter():
+    from heracles.core import multi_value_getter
 
-    assert toc_nearest({(1,): "x"}, 1) == "x"
-    assert toc_nearest({(1,): "x", (2,): "y", (): "z"}, 2) == "y"
-    assert toc_nearest({(1,): "x", (2,): "y", (): "z"}, (2, 0)) == "y"
-    assert toc_nearest({(1,): "x", (2,): "y", (): "z"}, (3, 0)) == "z"
-    assert toc_nearest({(0, 1): "x", (0, 2): "y", (0,): "z"}, (0, 2)) == "y"
-    assert toc_nearest({0: "x", 1: "y", (): "z"}, (0, 2)) == "x"
+    getter = multi_value_getter(
+        {
+            (1,): "x",
+            (2,): "y",
+            (): "z",
+            (2, 1): "w",
+            4: "v",
+        },
+    )
+
+    assert getter(1) == "x"
+    assert getter(2) == "y"
+    assert getter((2, 0)) == "y"
+    assert getter((3, 0)) == "z"
+    assert getter((2, 1)) == "w"
+    assert getter((4, 0)) == "v"
+
+    getter = multi_value_getter("x")
+
+    assert getter(1) == "x"
+    assert getter(2) == "x"
+    assert getter((2, 0)) == "x"
 
 
 def test_tocdict():


### PR DESCRIPTION
Move spherical harmonic transforms into mapper classes, since those are the objects that know how to carry out a transform of their maps.

Closes: #88