### PR TITLE
ENH(fields): add bias correction factor to metadata

### DIFF
--- a/heracles/io.py
+++ b/heracles/io.py
@@ -40,15 +40,22 @@ _METADATA_COMMENTS = {
     "spin": "spin weight of map",
     "kernel": "mapping kernel of map",
     "nside": "NSIDE parameter of HEALPix map",
+    "nbar": "mean number density",
+    "wbar": "mean weight density",
     "catalog_1": "catalog of first map",
     "spin_1": "spin weight of first map",
     "kernel_1": "mapping kernel of first map",
     "nside_1": "NSIDE parameter of first HEALPix map",
+    "nbar_1": "mean number density of first field",
+    "wbar_1": "mean weight density of first field",
     "catalog_2": "catalog of second map",
     "spin_2": "spin weight of second map",
     "kernel_2": "mapping kernel of second map",
     "nside_2": "NSIDE parameter of second HEALPix map",
-    "noisbias": "noise bias of spectrum",
+    "nbar_2": "mean number density of second field",
+    "wbar_2": "mean weight density of second field",
+    "bias": "additive bias of spectrum",
+    "bcor": "additive bias correction",
 }
 
 

--- a/heracles/twopoint.py
+++ b/heracles/twopoint.py
@@ -118,18 +118,27 @@ def angular_power_spectra(
 
         # collect metadata
         md = {}
+        bias, bcor = None, None
         if alm1.dtype.metadata:
             for key, value in alm1.dtype.metadata.items():
                 if key == "bias":
-                    md[key] = value if k1 == k2 and i1 == i2 else 0.0
+                    if k1 == k2 and i1 == i2:
+                        bias = value
+                elif key == "bcor":
+                    if k1 == k2 and i1 == i2:
+                        bcor = value
                 else:
                     md[f"{key}_1"] = value
         if alm2.dtype.metadata:
             for key, value in alm2.dtype.metadata.items():
-                if key == "bias":
+                if key == "bias" or key == "bcor":
                     pass
                 else:
                     md[f"{key}_2"] = value
+        if bias is not None:
+            md["bias"] = bias
+        if bcor is not None:
+            md["bcor"] = bcor
         update_metadata(cl, **md)
 
         # debias cl if asked to

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -263,6 +263,7 @@ def test_scalar_field(mapper, catalog):
     w = next(iter(catalog))["w"]
     v = next(iter(catalog))["g1"]
     v2 = ((w * v) ** 2).sum()
+    neff = w.sum() ** 2 / (w**2).sum()
     w = w.reshape(w.size // 4, 4).sum(axis=-1)
     wbar = w.mean()
     bias = (4 * np.pi / npix / npix) * v2
@@ -275,6 +276,7 @@ def test_scalar_field(mapper, catalog):
         "kernel": "healpix",
         "nside": mapper.nside,
         "bias": pytest.approx(bias / wbar**2),
+        "bcor": pytest.approx(4 * np.pi / neff),
     }
     np.testing.assert_array_almost_equal(m, 0)
 
@@ -291,6 +293,7 @@ def test_complex_field(mapper, catalog):
     re = next(iter(catalog))["g1"]
     im = next(iter(catalog))["g2"]
     v2 = ((w * re) ** 2 + (w * im) ** 2).sum()
+    neff = w.sum() ** 2 / (w**2).sum()
     w = w.reshape(w.size // 4, 4).sum(axis=-1)
     wbar = w.mean()
     bias = (4 * np.pi / npix / npix) * v2 / 2
@@ -303,6 +306,7 @@ def test_complex_field(mapper, catalog):
         "kernel": "healpix",
         "nside": mapper.nside,
         "bias": pytest.approx(bias / wbar**2),
+        "bcor": pytest.approx(2 * np.pi / neff),
     }
     np.testing.assert_array_almost_equal(m, 0)
 


### PR DESCRIPTION
Add a new metadata field `bcor` to maps generated by `ScalarField` and `ComplexField` which contains the factor for correcting the bias by the intrinsic field variance.

Closes: #54