### PR TITLE
ENH(io): new FITS file format

### DIFF
--- a/heracles/io.py
+++ b/heracles/io.py
@@ -36,27 +36,63 @@ logger = logging.getLogger(__name__)
 
 
 _METADATA_COMMENTS = {
-    "catalog": "catalog of map",
-    "spin": "spin weight of map",
-    "kernel": "mapping kernel of map",
-    "nside": "NSIDE parameter of HEALPix map",
-    "nbar": "mean number density",
-    "wbar": "mean weight density",
-    "catalog_1": "catalog of first map",
-    "spin_1": "spin weight of first map",
-    "kernel_1": "mapping kernel of first map",
-    "nside_1": "NSIDE parameter of first HEALPix map",
-    "nbar_1": "mean number density of first field",
-    "wbar_1": "mean weight density of first field",
-    "catalog_2": "catalog of second map",
-    "spin_2": "spin weight of second map",
-    "kernel_2": "mapping kernel of second map",
-    "nside_2": "NSIDE parameter of second HEALPix map",
-    "nbar_2": "mean number density of second field",
-    "wbar_2": "mean weight density of second field",
+    "catalog": "catalog of field",
+    "catalog_1": "catalog of first field",
+    "catalog_2": "catalog of second field",
+    "spin": "spin weight of field",
+    "spin1_": "spin weight of first field",
+    "spin2_": "spin weight of second field",
+    "geometry": "mapper geometry of field",
+    "geometry_1": "mapper geometry of first field",
+    "geometry_2": "mapper geometry of second field",
+    "kernel": "mapper kernel of field",
+    "kernel_1": "mapper kernel of first field",
+    "kernel_2": "mapper kernel of second field",
+    "nside": "HEALPix resolution parameter of field",
+    "nside_1": "HEALPix resolution parameter of first field",
+    "nside_2": "HEALPix resolution parameter of second field",
+    "lmax": "LMAX parameter of field",
+    "lmax_1": "LMAX parameter of first field",
+    "lmax_2": "LMAX parameter of second field",
+    "nbar": "mean number count of field",
+    "nbar_1": "mean number count of first field",
+    "nbar_2": "mean number count of second field",
+    "wbar": "mean weight of field",
+    "wbar_1": "mean weight of first field",
+    "wbar_2": "mean weight of second field",
     "bias": "additive bias of spectrum",
-    "bcor": "additive bias correction",
 }
+
+
+def _extname_from_key(key):
+    """
+    Return FITS extension name for a given key.
+    """
+    if not isinstance(key, tuple):
+        key = (key,)
+    return ",".join(map(str, key))
+
+
+def _key_from_extname(ext):
+    """
+    Return key for a given FITS extension name.
+    """
+    return tuple(int(s) if s.isdigit() else s for s in ext.split(","))
+
+
+def _iterfits(path, include=None, exclude=None):
+    """
+    Iterate over HDUs that correspond to valid keys.
+    """
+    with fitsio.FITS(path) as fits:
+        for hdu in fits:
+            extname = hdu.get_extname()
+            if not extname:
+                continue
+            key = _key_from_extname(extname)
+            if not toc_match(key, include=include, exclude=exclude):
+                continue
+            yield key, hdu
 
 
 def _write_metadata(hdu, metadata):
@@ -120,11 +156,11 @@ def _write_map(fits, ext, m, *, names=None):
     _write_metadata(fits[ext], m.dtype.metadata)
 
 
-def _read_map(fits, ext):
+def _read_map(hdu):
     """read HEALPix map from FITS table"""
 
     # read the map from the extension
-    m = fits[ext].read()
+    m = hdu.read()
 
     # turn the structured array of columns into an unstructured array
     # transpose so that columns become rows (as that is how maps are)
@@ -132,7 +168,7 @@ def _read_map(fits, ext):
     m = np.squeeze(np.lib.recfunctions.structured_to_unstructured(m).T)
 
     # read and attach metadata
-    m.dtype = np.dtype(m.dtype, metadata=_read_metadata(fits[ext]))
+    m.dtype = np.dtype(m.dtype, metadata=_read_metadata(hdu))
 
     return m
 
@@ -146,16 +182,16 @@ def _write_complex(fits, ext, arr):
     _write_metadata(fits[ext], arr.dtype.metadata)
 
 
-def _read_complex(fits, ext):
+def _read_complex(hdu):
     """read complex-valued data from FITS table"""
     # read structured data as complex array
-    raw = fits[ext].read()
+    raw = hdu.read()
     arr = np.empty(len(raw), dtype=complex)
     arr.real = raw["real"]
     arr.imag = raw["imag"]
     del raw
     # read and attach metadata
-    arr.dtype = np.dtype(arr.dtype, metadata=_read_metadata(fits[ext]))
+    arr.dtype = np.dtype(arr.dtype, metadata=_read_metadata(hdu))
     return arr
 
 
@@ -194,12 +230,12 @@ def _write_twopoint(fits, ext, arr, name):
     _write_metadata(fits[ext], arr.dtype.metadata)
 
 
-def _read_twopoint(fits, ext):
+def _read_twopoint(hdu):
     """read two-point data from FITS"""
     # read data from extension
-    arr = fits[ext].read()
+    arr = hdu.read()
     # read and attach metadata
-    arr.dtype = np.dtype(arr.dtype, metadata=_read_metadata(fits[ext]))
+    arr.dtype = np.dtype(arr.dtype, metadata=_read_metadata(hdu))
     return arr
 
 
@@ -249,40 +285,18 @@ def write_maps(
 
     # reopen FITS for writing data
     with fitsio.FITS(path, mode="rw", clobber=False) as fits:
-        # write a new TOC extension if FITS doesn't already contain one
-        if "MAPTOC" not in fits:
-            fits.create_table_hdu(
-                names=["EXT", "NAME", "BIN"],
-                formats=["10A", "10A", "I"],
-                extname="MAPTOC",
-            )
-
-        # get a recarray to write TOC entries with
-        tocentry = np.empty(1, dtype=fits["MAPTOC"].get_rec_dtype()[0])
-
-        # get the first free map extension index
-        mapn = 0
-        while f"MAP{mapn}" in fits:
-            mapn += 1
-
-        # write every map
-        for (n, i), m in maps.items():
+        for key, m in maps.items():
             # skip if not selected
-            if not toc_match((n, i), include=include, exclude=exclude):
+            if not toc_match(key, include=include, exclude=exclude):
                 continue
 
-            logger.info("writing %s map for bin %s", n, i)
+            logger.info("writing map %s", key)
 
             # the cl extension name
-            ext = f"MAP{mapn}"
-            mapn += 1
+            ext = _extname_from_key(key)
 
             # write the map in HEALPix FITS format
             _write_map(fits, ext, m)
-
-            # write the TOC entry
-            tocentry[0] = (ext, n, i)
-            fits["MAPTOC"].append(tocentry)
 
     logger.info("done with %d maps", len(maps))
 
@@ -298,23 +312,10 @@ def read_maps(filename, workdir=".", *, include=None, exclude=None):
     # the returned set of maps
     maps = TocDict()
 
-    # open the FITS file for reading
-    with fitsio.FITS(path) as fits:
-        # get the TOC from the FITS file
-        fits_toc = fits["MAPTOC"].read()
-
-        # read every entry in the TOC, add it to the list, then read the maps
-        for entry in fits_toc:
-            ext, n, i = entry[["EXT", "NAME", "BIN"]]
-
-            # skip if not selected
-            if not toc_match((n, i), include=include, exclude=exclude):
-                continue
-
-            logger.info("reading %s map for bin %s", n, i)
-
-            # read the map from the extension and store in set of maps
-            maps[n, i] = _read_map(fits, ext)
+    # iterate over valid HDUs in the file
+    for key, hdu in _iterfits(path, include=include, exclude=exclude):
+        logger.info("reading map %s", key)
+        maps[key] = _read_map(hdu)
 
     logger.info("done with %d maps", len(maps))
 
@@ -350,40 +351,18 @@ def write_alms(
 
     # reopen FITS for writing data
     with fitsio.FITS(path, mode="rw", clobber=False) as fits:
-        # write a new TOC extension if FITS doesn't already contain one
-        if "ALMTOC" not in fits:
-            fits.create_table_hdu(
-                names=["EXT", "NAME", "BIN"],
-                formats=["10A", "10A", "I"],
-                extname="ALMTOC",
-            )
-
-        # get a recarray to write TOC entries with
-        tocentry = np.empty(1, dtype=fits["ALMTOC"].get_rec_dtype()[0])
-
-        # get the first free alm extension index
-        almn = 0
-        while f"ALM{almn}" in fits:
-            almn += 1
-
-        # write every alm
-        for (n, i), alm in alms.items():
+        for key, alm in alms.items():
             # skip if not selected
-            if not toc_match((n, i), include=include, exclude=exclude):
+            if not toc_match(key, include=include, exclude=exclude):
                 continue
 
-            logger.info("writing %s alm for bin %s", n, i)
+            logger.info("writing alm %s", key)
 
             # the cl extension name
-            ext = f"ALM{almn}"
-            almn += 1
+            ext = _extname_from_key(key)
 
             # write the alm as structured data with metadata
             _write_complex(fits, ext, alm)
-
-            # write the TOC entry
-            tocentry[0] = (ext, n, i)
-            fits["ALMTOC"].append(tocentry)
 
     logger.info("done with %d alms", len(alms))
 
@@ -399,23 +378,10 @@ def read_alms(filename, workdir=".", *, include=None, exclude=None):
     # the returned set of alms
     alms = TocDict()
 
-    # open the FITS file for reading
-    with fitsio.FITS(path) as fits:
-        # get the TOC from the FITS file
-        fits_toc = fits["ALMTOC"].read()
-
-        # read every entry in the TOC, add it to the list, then read the alms
-        for entry in fits_toc:
-            ext, n, i = entry[["EXT", "NAME", "BIN"]]
-
-            # skip if not selected
-            if not toc_match((n, i), include=include, exclude=exclude):
-                continue
-
-            logger.info("reading %s alm for bin %s", n, i)
-
-            # read the alm from the extension and store in set of alms
-            alms[n, i] = _read_complex(fits, ext)
+    # iterate over valid HDUs in the file
+    for key, hdu in _iterfits(path, include=include, exclude=exclude):
+        logger.info("reading alm %s", key)
+        alms[key] = _read_complex(hdu)
 
     logger.info("done with %d alms", len(alms))
 
@@ -443,40 +409,18 @@ def write_cls(filename, cls, *, clobber=False, workdir=".", include=None, exclud
 
     # reopen FITS for writing data
     with fitsio.FITS(path, mode="rw", clobber=False) as fits:
-        # write a new TOC extension if FITS doesn't already contain one
-        if "CLTOC" not in fits:
-            fits.create_table_hdu(
-                names=["EXT", "NAME1", "NAME2", "BIN1", "BIN2"],
-                formats=["10A", "10A", "10A", "I", "I"],
-                extname="CLTOC",
-            )
-
-        # get a recarray to write TOC entries with
-        tocentry = np.empty(1, dtype=fits["CLTOC"].get_rec_dtype()[0])
-
-        # get the first free cl extension index
-        cln = 0
-        while f"CL{cln}" in fits:
-            cln += 1
-
-        # write every cl
-        for (k1, k2, i1, i2), cl in cls.items():
+        for key, cl in cls.items():
             # skip if not selected
-            if not toc_match((k1, k2, i1, i2), include=include, exclude=exclude):
+            if not toc_match(key, include=include, exclude=exclude):
                 continue
 
-            logger.info("writing %s x %s cl for bins %s, %s", k1, k2, i1, i2)
+            logger.info("writing cl %s", key)
 
             # the cl extension name
-            ext = f"CL{cln}"
-            cln += 1
+            ext = _extname_from_key(key)
 
             # write the data in structured format
             _write_twopoint(fits, ext, cl, "CL")
-
-            # write the TOC entry
-            tocentry[0] = (ext, k1, k2, i1, i2)
-            fits["CLTOC"].append(tocentry)
 
     logger.info("done with %d cls", len(cls))
 
@@ -492,23 +436,10 @@ def read_cls(filename, workdir=".", *, include=None, exclude=None):
     # the returned set of cls
     cls = TocDict()
 
-    # open the FITS file for reading
-    with fitsio.FITS(path) as fits:
-        # get the TOC from the FITS file
-        fits_toc = fits["CLTOC"].read()
-
-        # read every entry in the TOC, add it to the list, then read the cls
-        for entry in fits_toc:
-            ext, k1, k2, i1, i2 = entry[["EXT", "NAME1", "NAME2", "BIN1", "BIN2"]]
-
-            # skip if not selected
-            if not toc_match((k1, k2, i1, i2), include=include, exclude=exclude):
-                continue
-
-            logger.info("reading %s x %s cl for bins %s, %s", k1, k2, i1, i2)
-
-            # read the cl from the extension and store in set of cls
-            cls[k1, k2, i1, i2] = _read_twopoint(fits, ext)
+    # iterate over valid HDUs in the file
+    for key, hdu in _iterfits(path, include=include, exclude=exclude):
+        logger.info("reading cl %s", key)
+        cls[key] = _read_twopoint(hdu)
 
     logger.info("done with %d cls", len(cls))
 
@@ -536,40 +467,18 @@ def write_mms(filename, mms, *, clobber=False, workdir=".", include=None, exclud
 
     # reopen FITS for writing data
     with fitsio.FITS(path, mode="rw", clobber=False) as fits:
-        # write a new TOC extension if FITS doesn't already contain one
-        if "MMTOC" not in fits:
-            fits.create_table_hdu(
-                names=["EXT", "NAME1", "NAME2", "BIN1", "BIN2"],
-                formats=["10A", "10A", "10A", "I", "I"],
-                extname="MMTOC",
-            )
-
-        # get a recarray to write TOC entries with
-        tocentry = np.empty(1, dtype=fits["MMTOC"].get_rec_dtype()[0])
-
-        # get the first free mm extension index
-        mmn = 0
-        while f"MM{mmn}" in fits:
-            mmn += 1
-
-        # write every mixing matrix
-        for (k1, k2, i1, i2), mm in mms.items():
+        for key, mm in mms.items():
             # skip if not selected
-            if not toc_match((k1, k2, i1, i2), include=include, exclude=exclude):
+            if not toc_match(key, include=include, exclude=exclude):
                 continue
 
-            logger.info("writing %s x %s mm for bins %s, %s", k1, k2, i1, i2)
+            logger.info("writing mm %s", key)
 
             # the mm extension name
-            ext = f"MM{mmn}"
-            mmn += 1
+            ext = _extname_from_key(key)
 
             # write the data in structured format
             _write_twopoint(fits, ext, mm, "MM")
-
-            # write the TOC entry
-            tocentry[0] = (ext, k1, k2, i1, i2)
-            fits["MMTOC"].append(tocentry)
 
     logger.info("done with %d mm(s)", len(mms))
 
@@ -585,23 +494,10 @@ def read_mms(filename, workdir=".", *, include=None, exclude=None):
     # the returned set of mms
     mms = TocDict()
 
-    # open the FITS file for reading
-    with fitsio.FITS(path) as fits:
-        # get the TOC from the FITS file
-        fits_toc = fits["MMTOC"].read()
-
-        # read every entry in the TOC, add it to the list, then read the mms
-        for entry in fits_toc:
-            ext, k1, k2, i1, i2 = entry[["EXT", "NAME1", "NAME2", "BIN1", "BIN2"]]
-
-            # skip if not selected
-            if not toc_match((k1, k2, i1, i2), include=include, exclude=exclude):
-                continue
-
-            logger.info("writing %s x %s mm for bins %s, %s", k1, k2, i1, i2)
-
-            # read the mixing matrix from the extension and store in set of mms
-            mms[k1, k2, i1, i2] = _read_twopoint(fits, ext)
+    # iterate over valid HDUs in the file
+    for key, hdu in _iterfits(path, include=include, exclude=exclude):
+        logger.info("writing mm %s", key)
+        mms[key] = _read_twopoint(hdu)
 
     logger.info("done with %d mm(s)", len(mms))
 
@@ -629,41 +525,13 @@ def write_cov(filename, cov, clobber=False, workdir=".", include=None, exclude=N
 
     # reopen FITS for writing data
     with fitsio.FITS(path, mode="rw", clobber=False) as fits:
-        # write a new TOC extension if FITS doesn't already contain one
-        if "COVTOC" not in fits:
-            fits.create_table_hdu(
-                names=[
-                    "EXT",
-                    "NAME1_1",
-                    "NAME2_1",
-                    "BIN1_1",
-                    "BIN2_1",
-                    "NAME1_2",
-                    "NAME2_2",
-                    "BIN1_2",
-                    "BIN2_2",
-                ],
-                formats=["10A", "10A", "10A", "I", "I", "10A", "10A", "I", "I"],
-                extname="COVTOC",
-            )
-
-        # get a recarray to write TOC entries with
-        tocentry = np.empty(1, dtype=fits["COVTOC"].get_rec_dtype()[0])
-
-        # get the first free cov extension index
-        extn = 0
-        while f"COV{extn}" in fits:
-            extn += 1
-
-        # write every covariance sub-matrix
         for (k1, k2), mat in cov.items():
             # skip if not selected
             if not toc_match((k1, k2), include=include, exclude=exclude):
                 continue
 
             # the cl extension name
-            ext = f"COV{extn}"
-            extn += 1
+            ext = _extname_from_key(k1 + k2)
 
             logger.info("writing %s x %s covariance matrix", k1, k2)
 
@@ -682,10 +550,6 @@ def write_cov(filename, cov, clobber=False, workdir=".", include=None, exclude=N
             # write the metadata
             _write_metadata(fits[ext], mat.dtype.metadata)
 
-            # write the TOC entry
-            tocentry[0] = (ext, *k1, *k2)
-            fits["COVTOC"].append(tocentry)
-
     logger.info("done with %d covariance(s)", len(cov))
 
 
@@ -700,31 +564,20 @@ def read_cov(filename, workdir=".", *, include=None, exclude=None):
     # the returned set of covariances
     cov = TocDict()
 
-    # open the FITS file for reading
-    with fitsio.FITS(path) as fits:
-        # get the TOC from the FITS file
-        fits_toc = fits["COVTOC"].read()
+    # iterate over valid HDUs in the file
+    for key, hdu in _iterfits(path, include=include, exclude=exclude):
+        k1, k2 = key[: len(key) // 2], key[len(key) // 2 :]
 
-        # read every entry in the TOC, add it to the list, then read the data
-        for entry in fits_toc:
-            ext = entry["EXT"]
-            k1 = tuple(entry[["NAME1_1", "NAME2_1", "BIN1_1", "BIN2_1"]])
-            k2 = tuple(entry[["NAME1_2", "NAME2_2", "BIN1_2", "BIN2_2"]])
+        logger.info("reading %s x %s covariance matrix", k1, k2)
 
-            # skip if not selected
-            if not toc_match((k1, k2), include=include, exclude=exclude):
-                continue
+        # read the covariance matrix from the extension
+        mat = hdu.read()
 
-            logger.info("reading %s x %s covariance matrix", k1, k2)
+        # read and attach metadata
+        mat.dtype = np.dtype(mat.dtype, metadata=_read_metadata(hdu))
 
-            # read the covariance matrix from the extension
-            mat = fits[ext].read()
-
-            # read and attach metadata
-            mat.dtype = np.dtype(mat.dtype, metadata=_read_metadata(fits[ext]))
-
-            # store in set
-            cov[k1, k2] = mat
+        # store in set
+        cov[k1, k2] = mat
 
     logger.info("done with %d covariance(s)", len(cov))
 
@@ -734,12 +587,6 @@ def read_cov(filename, workdir=".", *, include=None, exclude=None):
 
 class TocFits(MutableMapping):
     """A FITS-backed TocDict."""
-
-    tag = "EXT"
-    """Tag for FITS extensions."""
-
-    columns = {}
-    """Columns and their formats in the FITS table of contents."""
 
     @staticmethod
     def reader(fits, ext):
@@ -767,38 +614,17 @@ class TocFits(MutableMapping):
     def __init__(self, path, *, clobber=False):
         self.path = Path(path)
 
-        # FITS extension for table of contents
-        self.ext = f"{self.tag.upper()}TOC"
-
         # if new or overwriting, create an empty FITS with primary HDU
         if not self.path.exists() or clobber:
             with fitsio.FITS(self.path, mode="rw", clobber=True) as fits:
                 fits.write(None)
 
-        # reopen FITS for writing data
+        # read extensions
         with self.fits as fits:
-            # write a new ToC extension if FITS doesn't already contain one
-            if self.ext not in fits:
-                fits.create_table_hdu(
-                    names=["EXT", *self.columns.keys()],
-                    formats=["10A", *self.columns.values()],
-                    extname=self.ext,
-                )
-
-                # get the dtype for ToC entries
-                self.dtype = fits[self.ext].get_rec_dtype()[0]
-
-                # empty ToC
-                self._toc = TocDict()
-            else:
-                # read existing ToC from FITS
-                toc = fits[self.ext].read()
-
-                # store the dtype for ToC entries
-                self.dtype = toc.dtype
-
-                # store the ToC as a mapping
-                self._toc = TocDict({tuple(key): str(ext) for ext, *key in toc})
+            self._toc = TocDict()
+            for hdu in fits:
+                if ext := hdu.get_extname():
+                    self._toc[_key_from_extname(ext)] = ext
 
         # set up a weakly-referenced cache for extension data
         self._cache = WeakValueDictionary()
@@ -846,18 +672,12 @@ class TocFits(MutableMapping):
         if key in self._toc:
             ext = self._toc[key]
         else:
-            extn = len(self._toc)
-            exts = set(self._toc.values())
-            while (ext := f"{self.tag.upper()}{extn}") in exts:
-                extn += 1
+            ext = _extname_from_key(key)
 
         # write data using the class writer, and update ToC as necessary
         with self.fits as fits:
             self.writer(fits, ext, value)
             if key not in self._toc:
-                tocentry = np.empty(1, dtype=self.dtype)
-                tocentry[0] = (ext, *key)
-                fits[self.ext].append(tocentry)
                 self._toc[key] = ext
 
     def __delitem__(self, key):
@@ -869,8 +689,6 @@ class TocFits(MutableMapping):
 class MapFits(TocFits):
     """FITS-backed mapping for maps."""
 
-    tag = "MAP"
-    columns = {"NAME": "10A", "BIN": "I"}
     reader = staticmethod(_read_map)
     writer = staticmethod(_write_map)
 
@@ -878,8 +696,6 @@ class MapFits(TocFits):
 class AlmFits(TocFits):
     """FITS-backed mapping for alms."""
 
-    tag = "ALM"
-    columns = {"NAME": "10A", "BIN": "I"}
     reader = staticmethod(_read_complex)
     writer = staticmethod(_write_complex)
 
@@ -887,16 +703,12 @@ class AlmFits(TocFits):
 class ClsFits(TocFits):
     """FITS-backed mapping for cls."""
 
-    tag = "CL"
-    columns = {"NAME1": "10A", "NAME2": "10A", "BIN1": "I", "BIN2": "I"}
     reader = staticmethod(_read_twopoint)
-    writer = partial(_write_twopoint, name=tag)
+    writer = partial(_write_twopoint, name="CL")
 
 
 class MmsFits(TocFits):
     """FITS-backed mapping for mixing matrices."""
 
-    tag = "MM"
-    columns = {"NAME1": "10A", "NAME2": "10A", "BIN1": "I", "BIN2": "I"}
     reader = staticmethod(_read_twopoint)
-    writer = partial(_write_twopoint, name=tag)
+    writer = partial(_write_twopoint, name="MM")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -181,7 +181,7 @@ def test_write_read_maps(rng, tmp_path):
         assert maps[key].dtype.metadata == maps_r[key].dtype.metadata
 
     # make sure map can be read by healpy
-    m = hp.read_map(tmp_path / "maps.fits", hdu="MAP0")
+    m = hp.read_map(tmp_path / "maps.fits", hdu="P,1")
     np.testing.assert_array_equal(maps["P", 1], m)
 
 
@@ -347,10 +347,7 @@ def test_tocfits(tmp_path):
     assert path.exists()
 
     with fitsio.FITS(path) as fits:
-        assert len(fits) == 2
-        toc = fits["TESTTOC"].read()
-    assert toc.dtype.names == ("EXT", "col1", "col2")
-    assert len(toc) == 0
+        assert len(fits) == 1
 
     assert len(tocfits) == 0
     assert list(tocfits) == []
@@ -363,28 +360,24 @@ def test_tocfits(tmp_path):
     tocfits[1, 2] = data12
 
     with fitsio.FITS(path) as fits:
-        assert len(fits) == 3
-        toc = fits["TESTTOC"].read()
-        assert len(toc) == 1
-        np.testing.assert_array_equal(fits["TEST0"].read(), data12)
+        assert len(fits) == 2
+        np.testing.assert_array_equal(fits["1,2"].read(), data12)
 
     assert len(tocfits) == 1
     assert list(tocfits) == [(1, 2)]
-    assert tocfits.toc == {(1, 2): "TEST0"}
+    assert tocfits.toc == {(1, 2): "1,2"}
     np.testing.assert_array_equal(tocfits[1, 2], data12)
 
     tocfits[2, 2] = data22
 
     with fitsio.FITS(path) as fits:
-        assert len(fits) == 4
-        toc = fits["TESTTOC"].read()
-        assert len(toc) == 2
-        np.testing.assert_array_equal(fits["TEST0"].read(), data12)
-        np.testing.assert_array_equal(fits["TEST1"].read(), data22)
+        assert len(fits) == 3
+        np.testing.assert_array_equal(fits["1,2"].read(), data12)
+        np.testing.assert_array_equal(fits["2,2"].read(), data22)
 
     assert len(tocfits) == 2
     assert list(tocfits) == [(1, 2), (2, 2)]
-    assert tocfits.toc == {(1, 2): "TEST0", (2, 2): "TEST1"}
+    assert tocfits.toc == {(1, 2): "1,2", (2, 2): "2,2"}
     np.testing.assert_array_equal(tocfits[1, 2], data12)
     np.testing.assert_array_equal(tocfits[2, 2], data22)
 
@@ -397,19 +390,17 @@ def test_tocfits(tmp_path):
 
     assert len(tocfits2) == 2
     assert list(tocfits2) == [(1, 2), (2, 2)]
-    assert tocfits2.toc == {(1, 2): "TEST0", (2, 2): "TEST1"}
+    assert tocfits2.toc == {(1, 2): "1,2", (2, 2): "2,2"}
     np.testing.assert_array_equal(tocfits2[1, 2], data12)
     np.testing.assert_array_equal(tocfits2[2, 2], data22)
 
     tocfits2[2, 1] = data21
 
     with fitsio.FITS(path) as fits:
-        assert len(fits) == 5
-        toc = fits["TESTTOC"].read()
-        assert len(toc) == 3
-        np.testing.assert_array_equal(fits["TEST0"].read(), data12)
-        np.testing.assert_array_equal(fits["TEST1"].read(), data22)
-        np.testing.assert_array_equal(fits["TEST2"].read(), data21)
+        assert len(fits) == 4
+        np.testing.assert_array_equal(fits["1,2"].read(), data12)
+        np.testing.assert_array_equal(fits["2,2"].read(), data22)
+        np.testing.assert_array_equal(fits["2,1"].read(), data21)
 
 
 def test_tocfits_is_lazy(tmp_path):
@@ -444,7 +435,7 @@ def test_tocfits_is_lazy(tmp_path):
 
     # make sure nothing is in the FITS
     with fitsio.FITS(path, "r") as fits:
-        assert len(fits) == 2
+        assert len(fits) == 1
 
     # make sure there are errors when acualising the generators
     with pytest.raises(OSError):


### PR DESCRIPTION
This change removes the use of a TOC extension for output FITS files. The dictionary keys themselves are now the extension names.  This removes the need for a hard-coded table of contents schema, and hence the ongoing issues with the SGS data model.

Closes: #125