### PR TITLE
BUG(io): make FITS compatible with data model

### DIFF
--- a/heracles/core.py
+++ b/heracles/core.py
@@ -31,6 +31,8 @@ T = TypeVar("T")
 
 def toc_match(key, include=None, exclude=None):
     """return whether a tocdict entry matches include/exclude criteria"""
+    if not isinstance(key, tuple):
+        key = (key,)
     if include is not None:
         for pattern in include:
             if all(p is Ellipsis or p == k for p, k in zip(pattern, key)):


### PR DESCRIPTION
Changes the FITS extension names back to a numbered schemed.  The dictionary key is now stored in the `DICTKEY` keyword.

Closes: #129