### PR TITLE
API(catalog): add sky fraction property to catalogue

### DIFF
--- a/heracles/catalog/fits.py
+++ b/heracles/catalog/fits.py
@@ -63,7 +63,7 @@ class FitsCatalog(CatalogBase):
 
     def __repr__(self):
         """string representation of FitsCatalog"""
-        s = self._path
+        s = str(self._path)
         if self._ext is not None:
             s = s + f"[{self._ext!r}]"
         return s

--- a/heracles/cli.py
+++ b/heracles/cli.py
@@ -233,10 +233,13 @@ def catalog_from_config(config, section, label=None, *, out=None):
     # set base catalogue's visibility if just one was given
     if isinstance(visibility, str):
         try:
-            base_catalog.visibility = read_vmap(getpath(visibility))
+            vmap = read_vmap(getpath(visibility))
         except (TypeError, ValueError, OSError) as exc:
             msg = f"Cannot load visibility: {exc!s}"
             raise ValueError(msg)
+        else:
+            base_catalog.visibility = vmap
+            del vmap
     # create a view of the base catalogue for each selection
     # since `out` can be given, also keep track of selections added here
     if out is None:
@@ -260,16 +263,19 @@ def catalog_from_config(config, section, label=None, *, out=None):
     # assign visibilities to individual selections if a mapping was given
     # only allow visibilities for selections added here
     if isinstance(visibility, Mapping):
-        for key, vmap in visibility.items():
+        for key, value in visibility.items():
             num = int(key)
             if num not in added:
                 msg = f"Invalid value: unknown selection '{num}'"
                 raise ValueError(msg)
             try:
-                out[num].visibility = read_vmap(getpath(vmap))
+                vmap = read_vmap(getpath(value))
             except (TypeError, ValueError, OSError) as exc:
                 msg = f"Cannot load visibility: {exc!s}"
                 raise ValueError(msg)
+            else:
+                out[num].visibility = vmap
+                del vmap
     # all done, return `out` unconditionally
     return out
 

--- a/heracles/fields.py
+++ b/heracles/fields.py
@@ -273,20 +273,17 @@ class Positions(Field, spin=0):
             vmap = hp.ud_grade(vmap, mapper.nside)
 
         # mean visibility (i.e. f_sky)
-        if vmap is None:
-            vbar = 1
-        else:
-            vbar = np.mean(vmap)
+        fsky = catalog.fsky if catalog.fsky is not None else 1.0
 
         # effective number of pixels
         npix = 4 * np.pi / mapper.area
 
         # compute average number count from map
-        nbar = ngal / vbar / npix
+        nbar = ngal / fsky / npix
         # override with provided value, but check that it makes sense
         if (nbar_ := self.nbar) is not None:
             # Poisson std dev from expected ngal assuming nbar_ is truth
-            sigma_nbar = (nbar_ / vbar / npix) ** 0.5
+            sigma_nbar = (nbar_ / fsky / npix) ** 0.5
             if abs(nbar - nbar_) > 3 * sigma_nbar:
                 warnings.warn(
                     f"The provided mean density ({nbar_:g}) differs from the "
@@ -361,20 +358,17 @@ class ScalarField(Field, spin=0):
             # clean up and yield control to main loop
             del page
 
-        # compute mean visibility
-        if catalog.visibility is None:
-            vbar = 1
-        else:
-            vbar = np.mean(catalog.visibility)
+        # sky fraction
+        fsky = catalog.fsky if catalog.fsky is not None else 1.0
 
         # compute mean weight per effective mapper "pixel"
-        wbar = ngal / (4 * np.pi * vbar) * wmean * mapper.area
+        wbar = ngal / (4 * np.pi * fsky) * wmean * mapper.area
 
         # normalise the map
         val /= wbar
 
         # compute bias from variance (per object)
-        bias = 4 * np.pi * vbar**2 * (var / wmean**2) / ngal
+        bias = 4 * np.pi * fsky**2 * (var / wmean**2) / ngal
 
         # set metadata of array
         update_metadata(val, catalog, wbar=wbar, bias=bias)
@@ -434,20 +428,17 @@ class ComplexField(Field, spin=0):
 
             del page
 
-        # compute mean visibility
-        if catalog.visibility is None:
-            vbar = 1
-        else:
-            vbar = np.mean(catalog.visibility)
+        # sky fraction
+        fsky = catalog.fsky if catalog.fsky is not None else 1.0
 
         # mean weight per effective mapper "pixel"
-        wbar = ngal / (4 * np.pi * vbar) * wmean * mapper.area
+        wbar = ngal / (4 * np.pi * fsky) * wmean * mapper.area
 
         # normalise the map
         val /= wbar
 
         # bias from measured variance, for E/B decomposition
-        bias = 2 * np.pi * vbar**2 * (var / wmean**2) / ngal
+        bias = 2 * np.pi * fsky**2 * (var / wmean**2) / ngal
 
         # set metadata of array
         update_metadata(val, catalog, wbar=wbar, bias=bias)
@@ -542,20 +533,17 @@ class Weights(Field, spin=0):
 
             del page
 
-        # compute mean visibility
-        if catalog.visibility is None:
-            vbar = 1
-        else:
-            vbar = np.mean(catalog.visibility)
+        # sky fraction
+        fsky = catalog.fsky if catalog.fsky is not None else 1.0
 
         # mean weight per effective mapper "pixel"
-        wbar = ngal / (4 * np.pi * vbar) * wmean * mapper.area
+        wbar = ngal / (4 * np.pi * fsky) * wmean * mapper.area
 
         # normalise the map
         wht /= wbar
 
         # bias from weights
-        bias = 4 * np.pi * vbar**2 * (w2mean / wmean**2) / ngal
+        bias = 4 * np.pi * fsky**2 * (w2mean / wmean**2) / ngal
 
         # set metadata of array
         update_metadata(wht, catalog, wbar=wbar, bias=bias)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -187,7 +187,7 @@ def test_catalog_base_properties(catalog):
 
     assert catalog.metadata == {"catalog": catalog.label}
 
-    v = object()
+    v = np.zeros(1)
     assert catalog.visibility is None
     catalog.visibility = v
     assert catalog.visibility is v
@@ -215,6 +215,7 @@ def test_catalog_base_copy():
         def __init__(self):
             super().__init__()
             self._visibility = object()
+            self._fsky = object()
 
         def _names(self):
             return []
@@ -236,6 +237,7 @@ def test_catalog_base_copy():
     assert copied is not catalog
     assert copied.__dict__ == catalog.__dict__
     assert copied.visibility is catalog.visibility
+    assert copied.fsky is catalog.fsky
     assert copied.filters is not catalog.filters
 
 
@@ -243,7 +245,8 @@ def test_catalog_view(catalog):
     from heracles.catalog import Catalog
 
     catalog.label = "label 123"
-    catalog.visibility = cvis = object()
+    catalog.visibility = cvis = np.zeros(1)
+    catalog.fsky = object()
 
     where = object()
 
@@ -259,11 +262,12 @@ def test_catalog_view(catalog):
     assert view.label == "label 123"
     assert view.selection is where
     assert view.visibility is catalog.visibility
+    assert view.fsky is catalog.fsky
 
     with pytest.raises(AttributeError):
         view.label = "different label"
 
-    view.visibility = vvis = object()
+    view.visibility = vvis = np.zeros(1)
 
     assert view.visibility is not catalog.visibility
     assert view.visibility is vvis

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -173,6 +173,8 @@ def test_fields_from_config(mock):
 def test_catalog_from_config(mock):
     from heracles.cli import ConfigParser, catalog_from_config
 
+    mock.return_value = np.zeros(1)
+
     # single visibility
 
     config = ConfigParser()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -70,6 +70,7 @@ def catalog(page):
     catalog = Mock()
     catalog.size = page.size
     catalog.visibility = None
+    catalog.fsky = None
     catalog.metadata = {"catalog": catalog.label}
     catalog.__iter__ = lambda self: iter([page])
 
@@ -225,7 +226,8 @@ def test_positions(mapper, catalog, vmap):
     # compute overdensity maps with visibility map
 
     catalog.visibility = vmap
-    nbar /= vmap.mean()
+    catalog.fsky = vmap.mean()
+    nbar /= catalog.fsky
 
     f = Positions(mapper, "ra", "dec")
     m = coroutines.run(f(catalog))


### PR DESCRIPTION
Adds a new `.fsky` property to the `Catalog` protocol, which is either computed from the visibility, or set directly.  Computing from visibility supports both maps and alms.

Changes all fields to use `catalog.fsky` instead of `catalog.visibility.mean()` to compute the mean density and additive bias.

Closes: #135