### PR TITLE
ENH(catalog): increase default catalogue page size

### DIFF
--- a/heracles/catalog/base.py
+++ b/heracles/catalog/base.py
@@ -312,7 +312,7 @@ class CatalogView:
 class CatalogBase(metaclass=ABCMeta):
     """abstract base class for base catalogues (not views)"""
 
-    default_page_size: int = 100_000
+    default_page_size: int = 1_000_000
     """default value for page size"""
 
     def __init__(self):


### PR DESCRIPTION
Increase the default page size when reading catalogues to 1,000,000 rows. This gives better reading performance across the board.

Closes: #139