### PR TITLE
DOC: Fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,6 @@ build:
   tools:
     python: "3.12"
 
-mkdocs:
-  configuration: mkdocs.yml
-
 sphinx:
   configuration: docs/conf.py
 

--- a/docs/manual/index.rst
+++ b/docs/manual/index.rst
@@ -6,5 +6,5 @@ Software manual
    :maxdepth: 2
 
    installation
-   Examples
+   examples
    releases


### PR DESCRIPTION
Fixes the .readthedocs.yml file for building sphinx docs.

Closes: #157
Reviewed-by: Nicolas Tessore