### PR TITLE
DEV: improve code style testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v0.5.7
     hooks:
       - id: ruff
-        args: [ --fix ]
+        args: [--fix]
       - id: ruff-format
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,10 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.286
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.7
     hooks:
       - id: ruff
+        args: [ --fix ]
+      - id: ruff-format
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.4
     hooks:
@@ -26,7 +28,3 @@ repos:
       - id: mixed-line-ending
         args: [--fix=lf]
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-      - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,19 +70,19 @@ testpaths = [
 ]
 
 [tool.ruff]
-include = ["pyproject.toml", "heracles/**/*.py", "tests/**/*.py"]
 extend-exclude = [
     "_kmeans_radec.py",
 ]
 force-exclude = true
-per-file-ignores = {"test_*" = [
+include = ["heracles/**/*.py", "pyproject.toml", "tests/**/*.py"]
+target-version = "py39"
+lint.per-file-ignores = {"test_*" = [
     "S101",
 ]}
-target-version = "py39"
-isort.known-first-party = [
+lint.isort.known-first-party = [
     "heracles",
 ]
-mccabe.max-complexity = 18
+lint.mccabe.max-complexity = 18
 
 [tool.tomlsort]
 all = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,6 @@ Documentation = "https://heracles.readthedocs.io/"
 Homepage = "https://github.com/heracles-ec/heracles"
 Issues = "https://github.com/heracles-ec/heracles/issues"
 
-[tool.black]
-force-exclude = """
-(
-  _kmeans_radec.py
-)
-"""
-
 [tool.hatch]
 build.hooks.vcs.version-file = "heracles/_version.py"
 version.source = "vcs"
@@ -77,41 +70,14 @@ testpaths = [
 ]
 
 [tool.ruff]
+include = ["pyproject.toml", "heracles/**/*.py", "tests/**/*.py"]
 extend-exclude = [
     "_kmeans_radec.py",
 ]
-fix = true
 force-exclude = true
-line-length = 100
 per-file-ignores = {"test_*" = [
     "S101",
 ]}
-select = [
-    "A",
-    "BLE",
-    "COM",
-    "DJ",
-    "DTZ",
-    "E",
-    "EM",
-    "ERA",
-    "EXE",
-    "F",
-    "I",
-    "ICN",
-    "INP",
-    "ISC",
-    "PIE",
-    "PYI",
-    "Q",
-    "RET",
-    "RSE",
-    "TCH",
-    "TID",
-    "UP",
-    "W",
-    "YTT",
-]
 target-version = "py39"
 isort.known-first-party = [
     "heracles",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,32 +8,26 @@ import pytest
 def test_getlist():
     from heracles.cli import getlist
 
-    assert (
-        getlist(
-            """
+    assert getlist(
+        """
                 x
                 y
                 z
             """,
-        )
-        == ["x", "y", "z"]
-    )
+    ) == ["x", "y", "z"]
     assert getlist("xyz") == ["xyz"]
 
 
 def test_getdict():
     from heracles.cli import getdict
 
-    assert (
-        getdict(
-            """
+    assert getdict(
+        """
                 x=1
                 y = 2
                 z= 3
             """,
-        )
-        == {"x": "1", "y": "2", "z": "3"}
-    )
+    ) == {"x": "1", "y": "2", "z": "3"}
 
     with pytest.raises(ValueError, match="Invalid value"):
         getdict(
@@ -70,15 +64,12 @@ def test_getfilter():
 
     assert getfilter("a") == [("a",)]
     assert getfilter("a, ..., 1, 2") == [("a", ..., 1, 2)]
-    assert (
-        getfilter(
-            """
+    assert getfilter(
+        """
                 a, 1
                 b, 2
             """,
-        )
-        == [("a", 1), ("b", 2)]
-    )
+    ) == [("a", 1), ("b", 2)]
 
 
 def test_subsections():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -72,9 +72,9 @@ def test_tocdict():
     assert d[...] == d
     assert d[()] == d
 
-    assert type(d.copy()) == type(d)
-    assert type(copy(d)) == type(d)
-    assert type(deepcopy(d)) == type(d)
+    assert type(d.copy()) is type(d)
+    assert type(copy(d)) is type(d)
+    assert type(deepcopy(d)) is type(d)
 
     d = TocDict(a=1) | TocDict(b=2)
     assert type(d) is TocDict

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -33,8 +33,7 @@ def page(nside, rng):
     from unittest.mock import Mock
 
     ipix = np.ravel(
-        4 * hp.ring2nest(nside, np.arange(12 * nside**2))[:, np.newaxis]
-        + [0, 1, 2, 3],
+        4 * hp.ring2nest(nside, np.arange(12 * nside**2))[:, np.newaxis] + [0, 1, 2, 3],
     )
 
     ra, dec = hp.pix2ang(nside * 2, ipix, nest=True, lonlat=True)


### PR DESCRIPTION
Now uses ruff's linter and formatter instead of black. Only applies to the `heracles` and `tests` folders.

Closes: #158
Reviewed-by: baugstein
