### PR TITLE
MNT(healpy,ducc): add external dependency explainer

### DIFF
--- a/heracles/ducc.py
+++ b/heracles/ducc.py
@@ -24,10 +24,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import ducc0
 import numpy as np
 
-from heracles.core import update_metadata
+from heracles.core import external_dependency_explainer, update_metadata
+
+with external_dependency_explainer:
+    import ducc0
 
 if TYPE_CHECKING:
     from collections.abc import Mapping

--- a/heracles/healpy.py
+++ b/heracles/healpy.py
@@ -25,11 +25,13 @@ from __future__ import annotations
 from functools import cached_property, wraps
 from typing import TYPE_CHECKING
 
-import healpy as hp
 import numpy as np
 from numba import njit
 
-from heracles.core import update_metadata
+from heracles.core import external_dependency_explainer, update_metadata
+
+with external_dependency_explainer:
+    import healpy as hp
 
 if TYPE_CHECKING:
     from collections.abc import Mapping


### PR DESCRIPTION
Use the `external_dependency_explainer` helper in the `heracles.healpy` and `heracles.ducc` module when optional external dependencies are imported.

Closes: #170