### PR TITLE
gh-204: include output in example

### DIFF
--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -1414,11 +1414,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Output\n",
+    "\n",
+    "Additionally, we can write the data we produced to file."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "heracles.write_cls(\"example-spectra.fits\", cls, clobber=True)\n",
+    "heracles.write_mms(\"example-mixmats.fits\", mms, clobber=True)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Adds a small section at the end of the example notebook where spectra and mixing matrices are written out to file.

Closes: #204