### PR TITLE
gh-207: simplified output format

### DIFF
--- a/heracles/twopoint.py
+++ b/heracles/twopoint.py
@@ -28,11 +28,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .core import TocDict, toc_match, update_metadata
+from .core import TocDict, update_metadata
 from .progress import NoProgress, Progress
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping, MutableMapping
+    from collections.abc import Mapping, MutableMapping
 
     from numpy.typing import ArrayLike, NDArray
 
@@ -42,6 +42,15 @@ if TYPE_CHECKING:
 TwoPointKey = tuple[Any, Any, Any, Any]
 
 logger = logging.getLogger(__name__)
+
+
+def alm_has_eb(alm: NDArray[Any]) -> bool:
+    """
+    Returns true if *alm* has a non-zero spin weight and a leading axis of size
+    2, false otherwise.
+    """
+    md = alm.dtype.metadata or {}
+    return alm.ndim > 1 and alm.shape[0] == 2 and md.get("spin", 0) != 0
 
 
 def alm2lmax(alm, mmax=None):
@@ -126,12 +135,18 @@ def _debias_cl(
 
     # minimum and maximum angular mode for bias correction
     lmin = max(abs(spin1), abs(spin2))
-    lmax = len(cl) - 1
+    lmax = cl.shape[-1] - 1
 
-    # this will be subtracted from the cl
-    # modes up to lmin are ignored
-    bl = np.full(lmax + 1, bias)
-    bl[:lmin] = 0.0
+    # this is what will be subtracted from the cl
+    bl = np.zeros(cl.shape)
+    if lmin > 0 and cl.ndim > 1:
+        # spin-weighted fields:
+        # - only remove from l >= lmin
+        # - only remove from EE and BB
+        bl[:2, ..., lmin:] = bias
+    else:
+        # scalar fields: remove from everywhere
+        bl[...] = bias
 
     # handle HEALPix pseudo-convolution
     for i, s in (1, spin1), (2, spin2):
@@ -149,7 +164,7 @@ def _debias_cl(
                 else:
                     pw = None
                 if pw is not None:
-                    bl[lmin:] /= pw[lmin:]
+                    bl[..., lmin:] /= pw[lmin:]
 
     # remove bias
     if cl.dtype.names is None:
@@ -160,40 +175,6 @@ def _debias_cl(
     return cl
 
 
-def _almkeys(
-    alms: Mapping[tuple[Any, Any], NDArray[Any]],
-) -> Iterator[tuple[str, Any]]:
-    """
-    Iterate with multidimensional alms flattened into separate keys.
-    """
-    for (k, i), alm in alms.items():
-        md = alm.dtype.metadata or {}
-        if alm.ndim < 2:
-            yield (k, i)
-        else:
-            eb = alm.shape[0] == 2 and md.get("spin", 0) != 0
-            for j in np.ndindex(*alm.shape[:-1]):
-                parts = [str(k), "EB"[j[0]] if eb else str(j[0]), *map(str, j[1:])]
-                yield ("_".join(parts), i)
-
-
-def _getalm(
-    alms: Mapping[tuple[Any, Any], NDArray[Any]],
-    k: str,
-    i: Any,
-) -> tuple[NDArray[Any], Mapping[str, Any]]:
-    """
-    Get alm and metadata from a flattened key.
-    """
-    k0, *parts = k.split("_")
-    alm = alms[k0, i]
-    md: Mapping[str, Any] = alm.dtype.metadata or {}
-    if parts and parts[0] in "EB":
-        parts[0] = ("EB").index(parts[0])
-    j = tuple(map(int, parts))
-    return alm[j], md
-
-
 def angular_power_spectra(
     alms,
     alms2=None,
@@ -202,8 +183,6 @@ def angular_power_spectra(
     debias=True,
     bins=None,
     weights=None,
-    include=None,
-    exclude=None,
     out=None,
 ):
     """compute angular power spectra from a set of alms"""
@@ -218,11 +197,12 @@ def angular_power_spectra(
     logger.info("using LMAX = %s for cls", lmax)
 
     # collect all alm combinations for computing cls
+    # iteration happens over keys only, values are accessed later
     if alms2 is None:
-        pairs = combinations_with_replacement(_almkeys(alms), 2)
+        pairs = combinations_with_replacement(alms, 2)
         alms2 = alms
     else:
-        pairs = product(_almkeys(alms), _almkeys(alms2))
+        pairs = product(alms, alms2)
 
     # keep track of the twopoint combinations we have seen here
     twopoint_names = set()
@@ -248,23 +228,52 @@ def angular_power_spectra(
         else:
             swapped = False
 
-        # check if cl is skipped by explicit include or exclude list
-        if not toc_match((k1, k2, i1, i2), include, exclude):
-            continue
-
         logger.info("computing %s x %s cl for bins %s, %s", k1, k2, i1, i2)
 
         # retrieve alms from keys; make sure swap is respected
         # this is done only now because alms might lazy-load from file
         if swapped:
-            alm1, md1 = _getalm(alms2, k1, i1)
-            alm2, md2 = _getalm(alms, k2, i2)
+            alm1, alm2 = alms2[k1, i1], alms[k2, i2]
         else:
-            alm1, md1 = _getalm(alms, k1, i1)
-            alm2, md2 = _getalm(alms2, k2, i2)
+            alm1, alm2 = alms[k1, i1], alms2[k2, i2]
 
-        # compute the raw cl from the alms
-        cl = alm2cl(alm1, alm2, lmax=lmax)
+        # get metadata from alms
+        md1 = alm1.dtype.metadata or {}
+        md2 = alm2.dtype.metadata or {}
+
+        # compute the set of spectra from the pair of alms
+        if alm_has_eb(alm1) and alm_has_eb(alm2):
+            # spin-spin
+            cl = np.stack(
+                [
+                    alm2cl(alm1[0], alm2[0], lmax=lmax),  # EE
+                    alm2cl(alm1[1], alm2[1], lmax=lmax),  # BB
+                    alm2cl(alm1[0], alm2[1], lmax=lmax),  # EB
+                    alm2cl(alm1[1], alm2[0], lmax=lmax),  # BE
+                ]
+            )
+            # trim BE == EB for auto-correlation
+            if k1 == k2 and i1 == i2:
+                cl = np.copy(cl[:3])
+        elif alm_has_eb(alm1):
+            # spin-scalar
+            cl = np.stack(
+                [
+                    alm2cl(alm1[0], alm2, lmax=lmax),  # TE
+                    alm2cl(alm1[1], alm2, lmax=lmax),  # TB
+                ]
+            )
+        elif alm_has_eb(alm2):
+            # spin-scalar
+            cl = np.stack(
+                [
+                    alm2cl(alm1, alm2[0], lmax=lmax),  # ET
+                    alm2cl(alm1, alm2[1], lmax=lmax),  # BT
+                ]
+            )
+        else:
+            # scalar-scalar
+            cl = alm2cl(alm1, alm2, lmax=lmax)  # TT
 
         # collect metadata
         md = {}
@@ -391,36 +400,20 @@ def mixing_matrices(
 
                 # if any spin is zero, then there is no E/B decomposition
                 if spin1 == 0 or spin2 == 0:
-                    mm = mixmat(
-                        cl,
-                        l1max=l1max,
-                        l2max=l2max,
-                        l3max=l3max,
-                        spin=(spin1, spin2),
-                    )
-                    if bins is not None:
-                        mm = bin2pt(mm, bins, "MM", weights=weights)
-                    name1 = f1 if spin1 == 0 else f"{f1}_E"
-                    name2 = f2 if spin2 == 0 else f"{f2}_E"
-                    out[name1, name2, i1, i2] = mm
-                    del mm
+                    mixmat_or_mixmat_eb = mixmat
                 else:
-                    # E/B decomposition for mixing matrix
-                    mm_ee, mm_bb, mm_eb = mixmat_eb(
-                        cl,
-                        l1max=l1max,
-                        l2max=l2max,
-                        l3max=l3max,
-                        spin=(spin1, spin2),
-                    )
-                    if bins is not None:
-                        mm_ee = bin2pt(mm_ee, bins, "MM", weights=weights)
-                        mm_bb = bin2pt(mm_bb, bins, "MM", weights=weights)
-                        mm_eb = bin2pt(mm_eb, bins, "MM", weights=weights)
-                    out[f"{f1}_E", f"{f2}_E", i1, i2] = mm_ee
-                    out[f"{f1}_B", f"{f2}_B", i1, i2] = mm_bb
-                    out[f"{f1}_E", f"{f2}_B", i1, i2] = mm_eb
-                    del mm_ee, mm_bb, mm_eb
+                    mixmat_or_mixmat_eb = mixmat_eb
+                mm = mixmat_or_mixmat_eb(
+                    cl,
+                    l1max=l1max,
+                    l2max=l2max,
+                    l3max=l3max,
+                    spin=(spin1, spin2),
+                )
+                if bins is not None:
+                    mm = bin2pt(mm, bins, "MM", weights=weights)
+                out[f1, f2, i1, i2] = mm
+                del mm
 
     # return the toc dict of mixing matrices
     return out

--- a/tests/test_twopoint.py
+++ b/tests/test_twopoint.py
@@ -10,24 +10,27 @@ def nside():
 
 
 @pytest.fixture
+def lmax():
+    return 32
+
+
+@pytest.fixture
 def zbins():
     return {0: (0.0, 0.8), 1: (1.0, 1.2)}
 
 
 @pytest.fixture
-def mock_alms(rng, zbins):
+def mock_alms(rng, zbins, lmax):
     import numpy as np
 
-    lmax = 32
-
-    Nlm = (lmax + 1) * (lmax + 2) // 2
+    size = (lmax + 1) * (lmax + 2) // 2
 
     # names and spins
-    fields = {"P": 0, "G": 2}
+    fields = {"POS": 0, "SHE": 2}
 
     alms = {}
     for n, s in fields.items():
-        shape = (Nlm, 2) if s == 0 else (2, Nlm, 2)
+        shape = (size, 2) if s == 0 else (2, size, 2)
         for i in zbins:
             a = rng.standard_normal(shape) @ [1, 1j]
             a.dtype = np.dtype(a.dtype, metadata={"nside": 32, "spin": s})
@@ -85,151 +88,90 @@ def test_alm2cl_unequal_size(rng):
     np.testing.assert_allclose(cl, hp.alm2cl(alm, alm21, lmax_out=lmax2))
 
 
-def test_almkeys():
-    from heracles.twopoint import _almkeys
-
-    dtype = np.dtype(complex)
-    spin2_dtype = np.dtype(complex, metadata={"spin": 2})
-
-    alms = {
-        ("A", 1): np.zeros((), dtype=dtype),
-        ("B", 2): np.zeros((2,), dtype=dtype),
-        ("C", 3): np.zeros((2, 10), dtype=dtype),
-        ("D", 4): np.zeros((2, 3, 10), dtype=dtype),
-        ("E", 5): np.zeros((2, 10), dtype=spin2_dtype),
-        ("F", 6): np.zeros((2, 3, 10), dtype=spin2_dtype),
-    }
-
-    keys = list(_almkeys(alms))
-
-    assert keys == [
-        ("A", 1),
-        ("B", 2),
-        ("C_0", 3),
-        ("C_1", 3),
-        ("D_0_0", 4),
-        ("D_0_1", 4),
-        ("D_0_2", 4),
-        ("D_1_0", 4),
-        ("D_1_1", 4),
-        ("D_1_2", 4),
-        ("E_E", 5),
-        ("E_B", 5),
-        ("F_E_0", 6),
-        ("F_E_1", 6),
-        ("F_E_2", 6),
-        ("F_B_0", 6),
-        ("F_B_1", 6),
-        ("F_B_2", 6),
-    ]
-
-
-def test_angular_power_spectra(mock_alms):
-    from itertools import combinations_with_replacement
-
+def test_angular_power_spectra(mock_alms, lmax):
     from heracles.twopoint import angular_power_spectra
 
-    order = ["P", "G_E", "G_B"]
-
-    fields = []
-    for (k, i), alm in mock_alms.items():
-        if alm.dtype.metadata["spin"] == 0:
-            fields.append((k, i))
-        else:
-            fields.append((f"{k}_E", i))
-            fields.append((f"{k}_B", i))
+    # expected combinations of input alms and their shapes
+    comb = {
+        ("POS", "POS", 0, 0): (lmax + 1,),
+        ("POS", "POS", 0, 1): (lmax + 1,),
+        ("POS", "POS", 1, 1): (lmax + 1,),
+        ("POS", "SHE", 0, 0): (2, lmax + 1),
+        ("POS", "SHE", 0, 1): (2, lmax + 1),
+        ("POS", "SHE", 1, 0): (2, lmax + 1),
+        ("POS", "SHE", 1, 1): (2, lmax + 1),
+        ("SHE", "SHE", 0, 0): (3, lmax + 1),
+        ("SHE", "SHE", 0, 1): (4, lmax + 1),
+        ("SHE", "SHE", 1, 1): (3, lmax + 1),
+    }
 
     # alms cross themselves
-
-    comb = {
-        (k1, k2, i1, i2) if order.index(k1) <= order.index(k2) else (k2, k1, i2, i1)
-        for (k1, i1), (k2, i2) in combinations_with_replacement(fields, 2)
-    }
-
     cls = angular_power_spectra(mock_alms)
-
-    assert cls.keys() == comb
+    keys = set(cls.keys())
+    assert keys == comb.keys()
+    for key, cl in cls.items():
+        assert cl.shape == comb[key]
 
     # explicit cross
-
     cls = angular_power_spectra(mock_alms, mock_alms)
-
-    assert cls.keys() == comb
-
-    # explicit include
-
-    cls = angular_power_spectra(
-        mock_alms,
-        include=[("P", "P", ..., ...), ("P", "G_E", ..., ...)],
-    )
-
-    assert cls.keys() == {
-        (k1, k2, i1, i2) if order.index(k1) <= order.index(k2) else (k2, k1, i2, i1)
-        for k1, k2, i1, i2 in comb
-        if (k1, k2) in [("P", "P"), ("P", "G_E")]
-    }
-
-    cls = angular_power_spectra(mock_alms, include=[("P", "P", 0), ("P", "G_E", 1)])
-
-    assert cls.keys() == {
-        (k1, k2, i1, i2) if order.index(k1) <= order.index(k2) else (k2, k1, i2, i1)
-        for k1, k2, i1, i2 in comb
-        if (k1, k2, i1) in [("P", "P", 0), ("P", "G_E", 1)]
-    }
-
-    # explicit exclude
-
-    cls = angular_power_spectra(
-        mock_alms,
-        exclude=[("P", "P"), ("P", "G_E"), ("P", "G_B")],
-    )
-
-    assert cls.keys() == {
-        (k1, k2, i1, i2) if order.index(k1) <= order.index(k2) else (k2, k1, i2, i1)
-        for k1, k2, i1, i2 in comb
-        if (k1, k2) not in [("P", "P"), ("P", "G_E"), ("P", "G_B")]
-    }
-
-    cls = angular_power_spectra(mock_alms, exclude=[(..., ..., 1, ...)])
-
-    assert cls.keys() == {(k1, k2, i1, i2) for k1, k2, i1, i2 in comb if i1 != 1}
+    keys = set(cls.keys())
+    assert keys == comb.keys()
+    for key, cl in cls.items():
+        assert cl.shape == comb[key]
 
     # explicit cross with separate alms
-
     mock_alms1 = {(k, i): alm for (k, i), alm in mock_alms.items() if i % 2 == 0}
     mock_alms2 = {(k, i): alm for (k, i), alm in mock_alms.items() if i % 2 == 1}
-    fields1 = [(k, i) for (k, i) in fields if i % 2 == 0]
-    fields2 = [(k, i) for (k, i) in fields if i % 2 == 1]
 
     comb12 = {
-        (k1, k2, i1, i2) if order.index(k1) <= order.index(k2) else (k2, k1, i2, i1)
-        for k1, i1 in fields1
-        for k2, i2 in fields2
+        ("POS", "POS", 0, 1): (lmax + 1,),
+        ("POS", "SHE", 0, 1): (2, lmax + 1),
+        ("POS", "SHE", 1, 0): (2, lmax + 1),
+        ("SHE", "SHE", 0, 1): (4, lmax + 1),
     }
 
     cls = angular_power_spectra(mock_alms1, mock_alms2)
-
-    assert cls.keys() == comb12
+    keys = set(cls.keys())
+    assert keys == comb12.keys()
+    for key, cl in cls.items():
+        assert cl.shape == comb12[key]
 
 
 def test_debias_cls():
     from heracles.twopoint import debias_cls
 
     cls = {
-        0: np.zeros(100),
-        2: np.zeros(100, dtype=np.dtype(float, metadata={"bias": 4.56, "spin_2": 2})),
+        "a": np.zeros(100),
+        "b": np.zeros(100, dtype=[("CL", float)]),
+        "c": np.zeros(
+            (2, 100), dtype=np.dtype(float, metadata={"bias": 4.56, "spin_2": 2})
+        ),
+        "d": np.zeros(
+            (4, 3, 100), dtype=np.dtype(float, metadata={"spin_1": 2, "spin_2": 2})
+        ),
     }
 
     nbs = {
-        0: 1.23,
+        "a": 1.23,
+        "b": 1.23,
+        "d": 7.89,
     }
 
     debias_cls(cls, nbs, inplace=True)
 
-    assert np.all(cls[0] == -1.23)
+    np.testing.assert_array_equal(cls["a"], -1.23)
 
-    assert np.all(cls[2][:2] == 0.0)
-    assert np.all(cls[2][2:] == -4.56)
+    np.testing.assert_array_equal(cls["b"]["CL"], -1.23)
+
+    np.testing.assert_array_equal(cls["c"][:, :2], 0.0)
+    np.testing.assert_array_equal(cls["c"][:, 2:], -4.56)
+
+    np.testing.assert_array_equal(cls["d"][0, :, :2], 0.0)
+    np.testing.assert_array_equal(cls["d"][0, :, 2:], -7.89)
+    np.testing.assert_array_equal(cls["d"][1, :, :2], 0.0)
+    np.testing.assert_array_equal(cls["d"][1, :, 2:], -7.89)
+    np.testing.assert_array_equal(cls["d"][2], 0.0)
+    np.testing.assert_array_equal(cls["d"][3], 0.0)
 
 
 def test_debias_cls_healpix():
@@ -261,9 +203,9 @@ def test_debias_cls_healpix():
     }
 
     cls = {
-        1: np.zeros(100, dtype=np.dtype(float, metadata=md1)),
-        2: np.zeros(100, dtype=np.dtype(float, metadata=md2)),
-        3: np.zeros(100, dtype=np.dtype(float, metadata=md3)),
+        1: np.zeros((2, 100), dtype=np.dtype(float, metadata=md1)),
+        2: np.zeros((2, 100), dtype=np.dtype(float, metadata=md2)),
+        3: np.zeros((2, 100), dtype=np.dtype(float, metadata=md3)),
     }
 
     nbs = {
@@ -274,14 +216,17 @@ def test_debias_cls_healpix():
 
     debias_cls(cls, nbs, inplace=True)
 
-    assert np.all(cls[1][:2] == 0.0)
-    assert np.all(cls[1][2:] == -1.23 / pw0[2:] / pw2[2:])
+    np.testing.assert_array_equal(cls[1][:, :2], 0.0)
+    np.testing.assert_array_equal(cls[1][0, 2:], -1.23 / pw0[2:] / pw2[2:])
+    np.testing.assert_array_equal(cls[1][1, 2:], -1.23 / pw0[2:] / pw2[2:])
 
-    assert np.all(cls[2][:2] == 0.0)
-    assert np.all(cls[2][2:] == -4.56 / pw0[2:])
+    np.testing.assert_array_equal(cls[2][:, :2], 0.0)
+    np.testing.assert_array_equal(cls[2][0, 2:], -4.56 / pw0[2:])
+    np.testing.assert_array_equal(cls[2][1, 2:], -4.56 / pw0[2:])
 
-    assert np.all(cls[3][:2] == 0.0)
-    assert np.all(cls[3][2:] == -7.89 / pw0[2:])
+    np.testing.assert_array_equal(cls[3][:, :2], 0.0)
+    np.testing.assert_array_equal(cls[3][0, 2:], -7.89 / pw0[2:])
+    np.testing.assert_array_equal(cls[3][1, 2:], -7.89 / pw0[2:])
 
 
 @patch("convolvecl.mixmat_eb")
@@ -328,8 +273,8 @@ def test_mixing_matrices(mock, mock_eb, rng):
         call(cl, l1max=None, l2max=None, l3max=None, spin=(0, 2)),
         call(cl, l1max=None, l2max=None, l3max=None, spin=(2, 0)),
     ]
-    assert mms["P", "G_E", 0, 1] is mock.return_value
-    assert mms["G_E", "P", 0, 1] is mock.return_value
+    assert mms["P", "G", 0, 1] is mock.return_value
+    assert mms["G", "P", 0, 1] is mock.return_value
 
     mock.reset_mock()
     mock_eb.reset_mock()
@@ -337,13 +282,11 @@ def test_mixing_matrices(mock, mock_eb, rng):
     # compute she-she
     cls = {("W", "W", 0, 1): cl}
     mms = mixing_matrices(fields, cls)
-    assert len(mms) == 3
+    assert len(mms) == 1
     assert mock.call_count == 0
     assert mock_eb.call_count == 1
     mock_eb.assert_called_with(cl, l1max=None, l2max=None, l3max=None, spin=(2, 2))
-    assert mms["G_E", "G_E", 0, 1] is mock_eb.return_value[0]
-    assert mms["G_B", "G_B", 0, 1] is mock_eb.return_value[1]
-    assert mms["G_E", "G_B", 0, 1] is mock_eb.return_value[2]
+    assert mms["G", "G", 0, 1] is mock_eb.return_value
 
     mock.reset_mock()
     mock_eb.reset_mock()


### PR DESCRIPTION
Simplifies the output format for Heracles' two-point products.

All two-point results are now produced as an array with keys corresponding to the input fields:

    {
        ("POS", "POS", 1, 1): ...,
        ("POS", "SHE", 1, 1): ...,
        ("SHE", "SHE", 1, 1): ...,
        ...
    }

For the output from `angular_power_spectra()`, the individual entries are

* 1D arrays with shape `(lmax + 1,)` for *TT*,
* 2D arrays with shape `(2, lmax + 1)` for *TE* and *TB*,
* 2D arrays with shape `(3, lmax + 1)` for *EE*, *BB*, *EB* of an auto-correlation (where *EB = BE*), and
* 2D arrays with shape `(4, lmax + 1)` for *EE*, *BB*, *EB*, *BE* of a cross-correlation (where *EB ≠ BE*).

For the output from `mixing_matrices()`, the individual entries are (in the notation of Brown, Castro & Taylor 2005):

* the $M^{TT,TT}$ mixing matrix for scalar x scalar,
* the $M^{TE,TE} = M^{TB,TB}$ mixing matrix for scalar x spin,
* the stack of mixing matrices
  
  * $M^{EE,EE} = M^{BB,BB}$,
  * $M^{EE,BB} = M^{BB,EE}$,
  * $M^{EB,EB}$

  for spin x spin.

In practice, this more compact storage of results, with everything for one combination of fields in one array, is generally more convenient (see example notebook).

Closes: #207