### PR TITLE
gh-217: install bzip2 before running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
           cache-dependency-path: "pyproject.toml"
+      - run: sudo apt-get install -y libbz2-dev # required to build fitsio
       - run: pip install -c .github/test-constraints.txt '.[test]'
       - run: pytest --cov=heracles --cov-report=lcov
       - uses: coverallsapp/github-action@v2


### PR DESCRIPTION
Explicitly installs the `bzip2` headers before attempting to build and install the `fitsio` package.

Closes: #217 