### PR TITLE
gh-223: fixes for NumPy 2

### DIFF
--- a/heracles/healpy.py
+++ b/heracles/healpy.py
@@ -48,7 +48,7 @@ def _nativebyteorder(fn):
         newargs = []
         for arr in args:
             if arr.dtype.byteorder != "=":
-                arr = arr.newbyteorder("=").byteswap()
+                arr = arr.view(arr.dtype.newbyteorder("=")).byteswap()
             newargs.append(arr)
         return fn(*newargs)
 

--- a/heracles/io.py
+++ b/heracles/io.py
@@ -214,6 +214,7 @@ def _write_map(fits, ext, key, m, *, names=None):
 
 def _read_map(hdu):
     """read HEALPix map from FITS table"""
+    from numpy.lib.recfunctions import structured_to_unstructured
 
     # read the map from the extension
     m = hdu.read()
@@ -221,7 +222,7 @@ def _read_map(hdu):
     # turn the structured array of columns into an unstructured array
     # transpose so that columns become rows (as that is how maps are)
     # then squeeze out degenerate axes
-    m = np.squeeze(np.lib.recfunctions.structured_to_unstructured(m).T)
+    m = np.squeeze(structured_to_unstructured(m).T)
 
     # read and attach metadata
     m.dtype = np.dtype(m.dtype, metadata=_read_metadata(hdu))

--- a/heracles/result.py
+++ b/heracles/result.py
@@ -79,8 +79,13 @@ class Result(np.ndarray):
         self.upper = getattr(obj, "upper", None)
         self.weight = getattr(obj, "weight", None)
 
-    def __array_wrap__(self, context=None, return_scalar=False):
-        return super().__array_wrap__(context, return_scalar).view(np.ndarray)
+    def __array_wrap__(self, arr, context=None, return_scalar=False):
+        out = super().__array_wrap__(arr, context)
+        if out is self or type(self) is not Result:
+            return out
+        if return_scalar:
+            return out.item()
+        return out.view(np.ndarray)
 
 
 def binned(result, bins, weight=None):


### PR DESCRIPTION
Fix for the removed `ndarray.newbyteorder()` method. Fixes for the `Result` warnings still TBD.

Closes: #223 