### PR TITLE
gh-228: results with multiple \ell axes

### DIFF
--- a/heracles/__init__.py
+++ b/heracles/__init__.py
@@ -64,7 +64,6 @@ __all__ = [
     "Progress",
     # result
     "Result",
-    "CovMatrix",
     "binned",
     # twopoint
     "angular_power_spectra",
@@ -132,7 +131,6 @@ from .progress import (
 
 from .result import (
     Result,
-    CovMatrix,
     binned,
 )
 

--- a/heracles/io.py
+++ b/heracles/io.py
@@ -265,39 +265,51 @@ def _read_complex(hdu):
     return arr
 
 
+def _prepare_result_array(arr, order, size):
+    """Prepare result array for writing."""
+
+    if len(order) == 1:
+        return arr[0]
+    return np.transpose([np.pad(arr[i], (0, size - arr[i].size)) for i in order])
+
+
 def _write_result(fits, ext, key, result):
     """
     Write a result array to FITS.
     """
 
-    # keep ndarray subclasses or we would lose all Result attributes
-    result = np.asanyarray(result)
+    from heracles.result import normalize_result_axis, get_result_array
 
-    # get ell axis
-    axis = getattr(result, "axis", result.ndim - 1)
+    # original unsorted ell and axis
+    _ell = getattr(result, "ell", None)
+    _axis = normalize_result_axis(getattr(result, "axis", None), result, _ell)
 
-    # get data & move ell axis to front
-    data = np.moveaxis(result, axis, 0)
+    # get decreasing order of ell axes in terms of dimension size
+    order = np.argsort([result.shape[i] for i in _axis])[::-1]
 
-    # get ell values or create default
-    ell = getattr(result, "ell", None)
-    if ell is None:
-        ell = np.arange(data.shape[0])
+    # get axis in new order
+    axis = tuple(_axis[i] for i in order)
 
-    # get lower bounds or create default
-    lower = getattr(result, "lower", None)
-    if lower is None:
-        lower = ell
+    # get data & move ell axes to front, largest first
+    data = np.moveaxis(result, axis, tuple(range(len(axis))))
 
-    # get upper array bounds or create default
-    upper = getattr(result, "upper", None)
-    if upper is None:
-        upper = np.append(ell[1:], ell[-1] + 1)
+    # length of largest axis will be the number of rows
+    nrows = data.shape[0]
 
-    # get weight array or create default
-    weight = getattr(result, "weight", None)
-    if weight is None:
-        weight = np.ones(data.shape[0])
+    # get data arrays
+    ell = _prepare_result_array(get_result_array(result, "ell"), order, nrows)
+    lower = _prepare_result_array(get_result_array(result, "lower"), order, nrows)
+    upper = _prepare_result_array(get_result_array(result, "upper"), order, nrows)
+    weight = _prepare_result_array(get_result_array(result, "weight"), order, nrows)
+
+    # construct the result header
+    header = [
+        dict(name="LAXIS", value=len(axis), comment="number of angular axes"),
+    ]
+    header += [
+        dict(name=f"LAXIS{i+1}", value=j, comment=f"index of angular axis {i+1}")
+        for i, j in enumerate(axis)
+    ]
 
     # write the result as columnar data
     fits.write_table(
@@ -316,10 +328,7 @@ def _write_result(fits, ext, key, result):
             "WEIGHT",
         ],
         extname=ext,
-        header=[
-            dict(name="ELLAXIS", value=1, comment="number of angular axes"),
-            dict(name="ELLAXIS1", value=axis, comment="index of angular axis 1"),
-        ],
+        header=header,
     )
 
     # write the metadata
@@ -336,23 +345,51 @@ def _read_result(hdu):
     h = hdu.read_header()
 
     # the angular axis
-    elldim = h["ELLAXIS"]
-    if elldim != 1:
-        raise NotImplementedError("multiple angular axes are not supported")
-    axis = tuple(h[f"ELLAXIS{i}"] for i in range(1, elldim + 1))
+    axis = tuple(h[f"LAXIS{i+1}"] for i in range(h["LAXIS"]))
 
     # get data array and move axis back to right position
-    result = np.moveaxis(data["ARRAY"], tuple(range(elldim)), axis)
+    arr = np.moveaxis(data["ARRAY"], tuple(range(len(axis))), axis)
+
+    # sort ell axes into natural order
+    order = np.argsort(axis)
+
+    # get ells
+    _ell = data["ELL"]
+    if _ell.ndim == 1:
+        ell = _ell
+    else:
+        ell = tuple(_ell[: arr.shape[j], i] for i, j in enumerate(order))
+
+    # get lower bounds
+    _lower = data["LOWER"]
+    if _lower.ndim == 1:
+        lower = _lower
+    else:
+        lower = tuple(_lower[: arr.shape[j], i] for i, j in enumerate(order))
+
+    # get upper bounds
+    _upper = data["UPPER"]
+    if _upper.ndim == 1:
+        upper = _upper
+    else:
+        upper = tuple(_upper[: arr.shape[j], i] for i, j in enumerate(order))
+
+    # get weights
+    _weight = data["WEIGHT"]
+    if _weight.ndim == 1:
+        weight = _weight
+    else:
+        weight = tuple(_weight[: arr.shape[j], i] for i, j in enumerate(order))
 
     # construct result array with ancillary arrays and metadata
     return Result(
-        result,
-        axis=axis[0] if elldim == 1 else axis,
-        ell=data["ELL"],
-        lower=data["LOWER"],
-        upper=data["UPPER"],
-        weight=data["WEIGHT"],
-    ).view(np.dtype(result.dtype, metadata=_read_metadata(hdu)))
+        arr.view(np.dtype(arr.dtype, metadata=_read_metadata(hdu))),
+        axis=tuple(axis[i] for i in order),
+        ell=ell,
+        lower=lower,
+        upper=upper,
+        weight=weight,
+    )
 
 
 def read_vmap(filename, nside=None, field=0, *, transform=False, lmax=None):

--- a/heracles/result.py
+++ b/heracles/result.py
@@ -115,69 +115,6 @@ class Result(np.ndarray):
         return out.view(np.ndarray)
 
 
-class CovMatrix(np.ndarray):
-    """
-    NumPy :class:`~numpy.ndarray` subclass with extra properties for
-    two-point covariance matrix.
-    """
-
-    __slots__ = (
-        "axis",
-        "ell_1",
-        "ell_2",
-        "lower_1",
-        "lower_2",
-        "upper_1",
-        "upper_2",
-        "weight_1",
-        "weight_2",
-    )
-
-    def __new__(
-        cls,
-        arr: NDArray[Any],
-        ell_1: NDArray[Any] | None = None,
-        ell_2: NDArray[Any] | None = None,
-        *,
-        lower_1: NDArray[Any] | None = None,
-        lower_2: NDArray[Any] | None = None,
-        upper_1: NDArray[Any] | None = None,
-        upper_2: NDArray[Any] | None = None,
-        weight_1: NDArray[Any] | None = None,
-        weight_2: NDArray[Any] | None = None,
-    ) -> Self:
-        obj = np.asarray(arr).view(cls)
-        obj.ell_1 = ell_1
-        obj.ell_2 = ell_2
-        obj.lower_1 = lower_1
-        obj.lower_2 = lower_2
-        obj.upper_1 = upper_1
-        obj.upper_2 = upper_2
-        obj.weight_1 = weight_1
-        obj.weight_2 = weight_2
-        return obj
-
-    def __array_finalize__(self, obj: NDArray[Any] | None) -> None:
-        if obj is None:
-            return
-        self.ell_1 = getattr(obj, "ell_1", None)
-        self.ell_2 = getattr(obj, "ell_2", None)
-        self.lower_1 = getattr(obj, "lower_1", None)
-        self.lower_2 = getattr(obj, "lower_2", None)
-        self.upper_1 = getattr(obj, "upper_1", None)
-        self.upper_2 = getattr(obj, "upper_2", None)
-        self.weight_1 = getattr(obj, "weight_1", None)
-        self.weight_2 = getattr(obj, "weight_2", None)
-
-    def __array_wrap__(self, arr, context=None, return_scalar=False):
-        out = super().__array_wrap__(arr, context)
-        if out is self or type(self) is not Result:
-            return out
-        if return_scalar:
-            return out.item()
-        return out.view(np.ndarray)
-
-
 def binned(result, bins, weight=None):
     """
     Compute binned results.

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -286,7 +286,7 @@ def test_write_read_cls(mock_cls, tmp_path):
     for key in mock_cls:
         assert key in cls
         cl, mock_cl = cls[key], mock_cls[key]
-        assert cl.axis == cl.ndim - 1
+        assert cl.axis == (cl.ndim - 1,)
         lmax = mock_cl.shape[-1] - 1
         np.testing.assert_array_equal(cl, mock_cl)
         np.testing.assert_array_equal(cl.ell, np.arange(lmax + 1))
@@ -316,7 +316,7 @@ def test_write_read_mms(rng, tmp_path):
     for key in mms:
         assert key in mms_
         mm = mms_[key]
-        assert mm.axis == mm.ndim - 2
+        assert mm.axis == (mm.ndim - 2,)
         lmax = mm.shape[-2] - 1
         np.testing.assert_array_equal(mm, mms[key])
         np.testing.assert_array_equal(mm.ell, np.arange(lmax + 1))

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -13,7 +13,7 @@ def test_result(rng):
     obj = heracles.Result(arr)
     np.testing.assert_array_equal(obj, arr)
     assert type(obj) is heracles.Result
-    assert obj.axis == 0
+    assert obj.axis == (0,)
     assert obj.ell is None
     assert obj.lower is None
     assert obj.upper is None
@@ -22,7 +22,7 @@ def test_result(rng):
     sliced = obj[1:]
     np.testing.assert_array_equal(sliced, arr[1:])
     assert type(sliced) is heracles.Result
-    assert sliced.axis == 0
+    assert sliced.axis == (0,)
     assert sliced.ell is None
     assert sliced.lower is None
     assert sliced.upper is None
@@ -35,7 +35,7 @@ def test_result(rng):
     obj = heracles.Result(arr, ell, lower=ellmin, upper=ellmax, weight=weight)
     np.testing.assert_array_equal(obj, arr)
     assert type(obj) is heracles.Result
-    assert obj.axis == 0
+    assert obj.axis == (0,)
     assert obj.ell is ell
     assert obj.lower is ellmin
     assert obj.upper is ellmax
@@ -44,7 +44,7 @@ def test_result(rng):
     sliced = obj[1:]
     np.testing.assert_array_equal(sliced, arr[1:])
     assert type(sliced) is heracles.Result
-    assert sliced.axis == 0
+    assert sliced.axis == (0,)
     assert sliced.ell is ell
     assert sliced.lower is ellmin
     assert sliced.upper is ellmax
@@ -58,7 +58,7 @@ def test_result(rng):
     assert obj.lower is ellmin
     assert obj.upper is ellmax
     assert obj.weight is weight
-    assert obj.axis == 0
+    assert obj.axis == (0,)
 
     copy = obj.copy()
     copy[:] += 1.0
@@ -68,7 +68,7 @@ def test_result(rng):
     assert copy.lower is ellmin
     assert copy.upper is ellmax
     assert copy.weight is weight
-    assert copy.axis == 0
+    assert copy.axis == (0,)
 
     view = obj.view(heracles.Result)
     np.testing.assert_array_equal(view, arr)
@@ -77,7 +77,7 @@ def test_result(rng):
     assert view.lower is ellmin
     assert view.upper is ellmax
     assert view.weight is weight
-    assert view.axis == 0
+    assert view.axis == (0,)
 
     with pytest.raises(ValueError, match="axis 1 is out of bounds"):
         heracles.Result([], axis=1)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -83,7 +83,7 @@ def test_result(rng):
         heracles.Result([], axis=1)
 
 
-def test_covmatrix(rng):
+def test_result_2d(rng):
     lmax1 = 30
     lmax2 = 200
     ell_1 = np.arange(lmax1 + 1)
@@ -95,53 +95,20 @@ def test_covmatrix(rng):
     weight_1 = rng.random((lmax1 + 1, lmax2 + 1))
     weight_2 = rng.random((lmax1 + 1, lmax2 + 1))
 
-    arr = rng.random((lmax1 + 1, lmax2 + 1))
-    obj = heracles.CovMatrix(
+    arr = rng.random((5, lmax1 + 1, lmax2 + 1))
+    obj = heracles.Result(
         arr,
-        ell_1,
-        ell_2,
-        lower_1=ellmin_1,
-        upper_1=ellmax_1,
-        lower_2=ellmin_2,
-        upper_2=ellmax_2,
-        weight_1=weight_1,
-        weight_2=weight_2,
+        (ell_1, ell_2),
+        lower=(ellmin_1, ellmin_2),
+        upper=(ellmax_1, ellmax_2),
+        weight=(weight_1, weight_2),
     )
     np.testing.assert_array_equal(obj, arr)
-    assert type(obj) is heracles.CovMatrix
-    assert obj.ell_1 is ell_1
-    assert obj.ell_2 is ell_2
-    assert obj.lower_1 is ellmin_1
-    assert obj.upper_1 is ellmax_1
-    assert obj.lower_2 is ellmin_2
-    assert obj.upper_2 is ellmax_2
-    assert obj.weight_1 is weight_1
-    assert obj.weight_2 is weight_2
-
-    copy = obj.copy()
-    copy[:] += 1.0
-    np.testing.assert_array_equal(copy, arr + 1.0)
-    assert type(copy) is heracles.CovMatrix
-    assert copy.ell_1 is ell_1
-    assert copy.ell_2 is ell_2
-    assert copy.lower_1 is ellmin_1
-    assert copy.upper_1 is ellmax_1
-    assert copy.lower_2 is ellmin_2
-    assert copy.upper_2 is ellmax_2
-    assert copy.weight_1 is weight_1
-    assert copy.weight_2 is weight_2
-
-    view = obj.view(heracles.CovMatrix)
-    np.testing.assert_array_equal(view, arr)
-    assert type(view) is heracles.CovMatrix
-    assert view.ell_1 is ell_1
-    assert view.ell_2 is ell_2
-    assert view.lower_1 is ellmin_1
-    assert view.upper_1 is ellmax_1
-    assert view.lower_2 is ellmin_2
-    assert view.upper_2 is ellmax_2
-    assert view.weight_1 is weight_1
-    assert view.weight_2 is weight_2
+    assert obj.axis == (1, 2)
+    assert obj.ell == (ell_1, ell_2)
+    assert obj.lower == (ellmin_1, ellmin_2)
+    assert obj.upper == (ellmax_1, ellmax_2)
+    assert obj.weight == (weight_1, weight_2)
 
 
 @pytest.mark.parametrize("weight", [None, "l(l+1)", "2l+1", "<rand>"])

--- a/tests/test_twopoint.py
+++ b/tests/test_twopoint.py
@@ -111,7 +111,7 @@ def test_angular_power_spectra(mock_alms, lmax):
     assert keys == comb.keys()
     for key, cl in cls.items():
         assert cl.shape == comb[key]
-        assert cl.axis == cl.ndim - 1
+        assert cl.axis == (cl.ndim - 1,)
 
     # explicit cross
     cls = angular_power_spectra(mock_alms, mock_alms)
@@ -276,7 +276,7 @@ def test_mixing_matrices(mock, mock_eb, lmax, rng):
     assert mock_eb.call_count == 0
     mock.assert_called_with(cl, l1max=None, l2max=None, l3max=None, spin=(0, 0))
     assert mms["POS", "POS", 0, 1].base is mock.return_value
-    assert mms["POS", "POS", 0, 1].axis == 0
+    assert mms["POS", "POS", 0, 1].axis == (0,)
 
     mock.reset_mock()
     mock_eb.reset_mock()
@@ -292,9 +292,9 @@ def test_mixing_matrices(mock, mock_eb, lmax, rng):
         call(cl, l1max=None, l2max=None, l3max=None, spin=(2, 0)),
     ]
     assert mms["POS", "SHE", 0, 1].base is mock.return_value
-    assert mms["POS", "SHE", 0, 1].axis == 0
+    assert mms["POS", "SHE", 0, 1].axis == (0,)
     assert mms["SHE", "POS", 0, 1].base is mock.return_value
-    assert mms["SHE", "POS", 0, 1].axis == 0
+    assert mms["SHE", "POS", 0, 1].axis == (0,)
 
     mock.reset_mock()
     mock_eb.reset_mock()
@@ -307,7 +307,7 @@ def test_mixing_matrices(mock, mock_eb, lmax, rng):
     assert mock_eb.call_count == 1
     mock_eb.assert_called_with(cl, l1max=None, l2max=None, l3max=None, spin=(2, 2))
     assert mms["SHE", "SHE", 0, 1].base is mock_eb.return_value
-    assert mms["SHE", "SHE", 0, 1].axis == 1
+    assert mms["SHE", "SHE", 0, 1].axis == (1,)
 
     mock.reset_mock()
     mock_eb.reset_mock()


### PR DESCRIPTION
Adds support for multiple $\ell$ axes to the `Result` class. This can be used to read and write, e.g., covariance matrices.

I had to add this to `Result` instead of the `CovMatrix` class since I couldn't figure out a good way to recover the correct class (`Result`, `CovMatrix`, or potentially classes for spectra or mixing matrices) from either `read()` or `binned()`. With one multi-purpose class, the problem doesn't arise.

To create a covariance matrix or other result with a second $\ell$ axis:

```py
cov = heracles.Result(
    arr,
    ell=(ell_1, ell_2),  # optional
    axis=(-2, -1),  # optional
    lower=(lower_1, lower_2),  # optional
    upper=(upper_1, upper_2),  # optional
    weight=(weight_1, weight_2),  # optional
)
```
What determines the $\ell$-dimension of the result is the value of `result.axis`. If `axis` is not given explicitly, the last `len(ell)` axes are used (e.g. -2, -1). So either `ell` or `axis` must be given for multiple $\ell$ axes, otherwise, a single $\ell$ axis of -1 is assumed.

Closes: #228