### PR TITLE
gh-236: make Result container not array subclass

### DIFF
--- a/heracles/io.py
+++ b/heracles/io.py
@@ -290,11 +290,11 @@ def _write_result(fits, ext, key, result):
     # get axis in new order
     axis = tuple(_axis[i] for i in order)
 
-    # get data & move ell axes to front, largest first
-    data = np.moveaxis(result, axis, tuple(range(len(axis))))
+    # get array & move ell axes to front, largest first
+    arr = np.moveaxis(result, axis, tuple(range(len(axis))))
 
     # length of largest axis will be the number of rows
-    nrows = data.shape[0]
+    nrows = arr.shape[0]
 
     # get data arrays
     ell = _prepare_result_array(get_result_array(result, "ell"), order, nrows)
@@ -311,7 +311,7 @@ def _write_result(fits, ext, key, result):
     # write the result as columnar data
     fits.write_table(
         [
-            data,
+            arr,
             ell,
             lower,
             upper,

--- a/heracles/twopoint.py
+++ b/heracles/twopoint.py
@@ -281,9 +281,6 @@ def angular_power_spectra(
             # scalar-scalar
             cl = alm2cl(alm1, alm2, lmax=lmax)  # TT
 
-        # wrap in result array type
-        cl = Result(cl, axis=-1)
-
         # collect metadata
         md = {}
         bias = None
@@ -305,12 +302,16 @@ def angular_power_spectra(
         if debias and bias is not None:
             _debias_cl(cl, bias, md, inplace=True)
 
+        # write metadata for this spectrum
+        update_metadata(cl, **md)
+
+        # wrap in result array type
+        # do this before binned() so it picks up the correct ell axes
+        cl = Result(cl, axis=-1)
+
         # if bins are given, apply the binning
         if bins is not None:
             cl = binned(cl, bins, weights)
-
-        # write metadata for this spectrum
-        update_metadata(cl, **md)
 
         # add cl to the set
         cls[k1, k2, i1, i2] = cl

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -13,6 +13,7 @@ def test_result(rng):
     obj = heracles.Result(arr)
     np.testing.assert_array_equal(obj, arr)
     assert type(obj) is heracles.Result
+    assert obj.array is arr
     assert obj.axis == (0,)
     assert obj.ell is None
     assert obj.lower is None
@@ -21,12 +22,7 @@ def test_result(rng):
 
     sliced = obj[1:]
     np.testing.assert_array_equal(sliced, arr[1:])
-    assert type(sliced) is heracles.Result
-    assert sliced.axis == (0,)
-    assert sliced.ell is None
-    assert sliced.lower is None
-    assert sliced.upper is None
-    assert sliced.weight is None
+    assert type(sliced) is np.ndarray
 
     ell = np.arange(lmax + 1)
     ellmin = ell
@@ -35,6 +31,7 @@ def test_result(rng):
     obj = heracles.Result(arr, ell, lower=ellmin, upper=ellmax, weight=weight)
     np.testing.assert_array_equal(obj, arr)
     assert type(obj) is heracles.Result
+    assert obj.array is arr
     assert obj.axis == (0,)
     assert obj.ell is ell
     assert obj.lower is ellmin
@@ -43,44 +40,21 @@ def test_result(rng):
 
     sliced = obj[1:]
     np.testing.assert_array_equal(sliced, arr[1:])
-    assert type(sliced) is heracles.Result
-    assert sliced.axis == (0,)
-    assert sliced.ell is ell
-    assert sliced.lower is ellmin
-    assert sliced.upper is ellmax
-    assert sliced.weight is weight
+    assert type(sliced) is np.ndarray
 
     arr = rng.random((lmax + 1, 100))
     obj = heracles.Result(arr, ell, lower=ellmin, upper=ellmax, weight=weight, axis=0)
     np.testing.assert_array_equal(obj, arr)
     assert type(obj) is heracles.Result
+    assert obj.array is arr
     assert obj.ell is ell
     assert obj.lower is ellmin
     assert obj.upper is ellmax
     assert obj.weight is weight
     assert obj.axis == (0,)
 
-    copy = obj.copy()
-    copy[:] += 1.0
-    np.testing.assert_array_equal(copy, arr + 1.0)
-    assert type(copy) is heracles.Result
-    assert copy.ell is ell
-    assert copy.lower is ellmin
-    assert copy.upper is ellmax
-    assert copy.weight is weight
-    assert copy.axis == (0,)
-
-    view = obj.view(heracles.Result)
-    np.testing.assert_array_equal(view, arr)
-    assert type(view) is heracles.Result
-    assert view.ell is ell
-    assert view.lower is ellmin
-    assert view.upper is ellmax
-    assert view.weight is weight
-    assert view.axis == (0,)
-
     with pytest.raises(ValueError, match="axis 1 is out of bounds"):
-        heracles.Result([], axis=1)
+        heracles.Result(np.array([]), axis=1)
 
 
 def test_result_2d(rng):

--- a/tests/test_twopoint.py
+++ b/tests/test_twopoint.py
@@ -275,7 +275,7 @@ def test_mixing_matrices(mock, mock_eb, lmax, rng):
     assert mock.call_count == 1
     assert mock_eb.call_count == 0
     mock.assert_called_with(cl, l1max=None, l2max=None, l3max=None, spin=(0, 0))
-    assert mms["POS", "POS", 0, 1].base is mock.return_value
+    assert mms["POS", "POS", 0, 1].array is mock.return_value
     assert mms["POS", "POS", 0, 1].axis == (0,)
 
     mock.reset_mock()
@@ -291,9 +291,9 @@ def test_mixing_matrices(mock, mock_eb, lmax, rng):
         call(cl, l1max=None, l2max=None, l3max=None, spin=(0, 2)),
         call(cl, l1max=None, l2max=None, l3max=None, spin=(2, 0)),
     ]
-    assert mms["POS", "SHE", 0, 1].base is mock.return_value
+    assert mms["POS", "SHE", 0, 1].array is mock.return_value
     assert mms["POS", "SHE", 0, 1].axis == (0,)
-    assert mms["SHE", "POS", 0, 1].base is mock.return_value
+    assert mms["SHE", "POS", 0, 1].array is mock.return_value
     assert mms["SHE", "POS", 0, 1].axis == (0,)
 
     mock.reset_mock()
@@ -306,7 +306,7 @@ def test_mixing_matrices(mock, mock_eb, lmax, rng):
     assert mock.call_count == 0
     assert mock_eb.call_count == 1
     mock_eb.assert_called_with(cl, l1max=None, l2max=None, l3max=None, spin=(2, 2))
-    assert mms["SHE", "SHE", 0, 1].base is mock_eb.return_value
+    assert mms["SHE", "SHE", 0, 1].array is mock_eb.return_value
     assert mms["SHE", "SHE", 0, 1].axis == (1,)
 
     mock.reset_mock()


### PR DESCRIPTION
This changes the `Result` class to be a container holding an array, but not be an array subclass itself. Having it be an array subclass leads to problems such as #236.

The container forwards basic operations such as `result[...]`, `result.ndim`, `result.shape` to the array (more could be added). So users can still do

```py
# cl_sheshe is a result of shape (3, lmax + 1)
plt.plot(ell, cl_sheshe[0])  # plot EE spectrum
```

The result also has an `__array__()` method that returns the contained array in a numpy context, so this works even if `result` is no longer an array itself:

```py
# any numpy function will do
np.multiply(result, 1)
```