### PR TITLE
gh-227: implement binned() for multiple ell axes

### DIFF
--- a/heracles/result.py
+++ b/heracles/result.py
@@ -169,7 +169,7 @@ def binned(result, bins, weight=None):
     dt = np.dtype(float, metadata=md)
 
     # make a copy of the array to apply the binning
-    out = np.asarray(result, dtype=dt, copy=True)
+    out = np.copy(result).view(dt)
 
     # this will hold the binned ells and weigths
     binned_ell: tuple[NDArray[Any], ...] | NDArray[Any] = ()

--- a/heracles/result.py
+++ b/heracles/result.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
     from typing import Any
     from numpy.typing import NDArray, DTypeLike
 
+from heracles.core import update_metadata
+
 
 def normalize_result_axis(axis, result, ell):
     """Return an axis tuple for a result."""
@@ -128,76 +130,104 @@ def binned(result, bins, weight=None):
         out = np.zeros(np.broadcast(a, b).shape)
         return np.divide(a, b, where=(a != 0), out=out)
 
-    # flatten list of bins
-    bins = np.reshape(bins, -1)
-    m = bins.size
+    # store metadata of result to later copy it into the binned array
+    md = result.dtype.metadata
 
-    # shape of the data
-    ellaxis = getattr(result, "axis", None)
-    if ellaxis is None:
-        ellaxis = (result.ndim - 1,)
-    if len(ellaxis) != 1:
-        # multi-binning not implemented yet
-        raise NotImplementedError("only 1D binning is supported")
-    axis = ellaxis[0]
-    shape = result.shape
-    n = shape[axis]
+    # get ell values from result
+    ells = get_result_array(result, "ell")
 
-    # get ell from results or assume [0, n)
-    ell = getattr(result, "ell", None)
-    if ell is None:
-        ell = np.arange(n)
+    # get normalised axis tuple from result
+    axes = normalize_result_axis(getattr(result, "axis", None), result, ells)
 
     # combine weights of result with weights from string or given array
-    w = getattr(result, "weight", None)
-    if w is None:
-        w = np.ones(n)
-    if weight is None:
-        pass
-    elif isinstance(weight, str):
-        if weight == "l(l+1)":
-            w *= ell * (ell + 1)
-        elif weight == "2l+1":
-            w *= 2 * ell + 1
+    weights = []
+    for ell, w in zip(ells, get_result_array(result, "weight")):
+        if weight is None:
+            pass
+        elif isinstance(weight, str):
+            if weight == "l(l+1)":
+                w = ell * (ell + 1) * w
+            elif weight == "2l+1":
+                w = (2 * ell + 1) * w
+            else:
+                msg = f"unknown weights string: {weight}"
+                raise ValueError(msg)
         else:
-            msg = f"unknown weights string: {weight}"
-            raise ValueError(msg)
-    else:
-        w *= weight[:n]
+            w = weight[: w.size] * w
+        weights.append(w)
 
-    # get the bin index for each ell
-    index = np.digitize(ell, bins)
+    # normalise bins into a tuple if a single set is given
+    if not isinstance(bins, tuple):
+        bins = (bins,) * len(axes)
 
-    assert index.size == ell.size
+    # make sure length of given bins matches ell axes
+    if len(bins) != len(axes):
+        raise ValueError("result and bins have different number of ell axes")
 
-    # compute the binned weight
-    wb = np.bincount(index, weights=w, minlength=m)[1:m]
+    # flatten all bins
+    bins = tuple(np.reshape(b, -1) for b in bins)
 
-    # construct output dtype with metadata
-    md = {}
-    if result.dtype.metadata:
-        md.update(result.dtype.metadata)
-    dt = np.dtype(float, metadata=md)
+    # make a copy of the array to apply the binning
+    result = np.copy(result)
 
-    # create an empty binned output array
-    sh = shape[:axis] + (m - 1,) + shape[axis + 1 :]
-    out = np.empty(sh, dtype=dt)
+    # this will hold the binned ells and weigths
+    binned_ell: tuple[NDArray[Any], ...] | NDArray[Any] = ()
+    binned_weight: tuple[NDArray[Any], ...] | NDArray[Any] = ()
 
-    # compute the binned result axis by axis
-    for i in np.ndindex(shape[:axis]):
-        for j in np.ndindex(shape[axis + 1 :]):
-            k = (*i, slice(None), *j)
-            out[k] = norm(np.bincount(index, w * result[k], m)[1:m], wb)
+    # apply binning over each axis
+    for axis, ell, w, b in zip(axes, ells, weights, bins):
+        # number of bins for this axis
+        m = b.size
 
-    # compute the binned ell
-    ell = norm(np.bincount(index, w * ell, m)[1:m], wb)
+        # get the bin index for each ell
+        index = np.digitize(ell, b)
+
+        # compute the binned weight
+        wb = np.bincount(index, weights=w, minlength=m)[1:m]
+
+        # compute the binned ell
+        ellb = norm(np.bincount(index, w * ell, m)[1:m], wb)
+
+        # output shape, axis is turned into size m
+        shape = result.shape[:axis] + (m - 1,) + result.shape[axis + 1 :]
+
+        # create an empty binned output array
+        tmp = np.empty(shape, dtype=float)
+
+        # compute the binned result axis by axis
+        for before in np.ndindex(shape[:axis]):
+            for after in np.ndindex(shape[axis + 1 :]):
+                k = (*before, slice(None), *after)
+                tmp[k] = norm(np.bincount(index, w * result[k], m)[1:m], wb)
+
+        # array is now binned over axis
+        result = tmp
+
+        # store outputs
+        binned_ell += (ellb,)
+        binned_weight += (wb,)
+
+    # compute bin edges
+    binned_lower = tuple(b[:-1] for b in bins)
+    binned_upper = tuple(b[1:] for b in bins)
+
+    # copy the metadata from the original input
+    if md is not None:
+        update_metadata(result, **md)
+
+    # return plain arrays when there is a single ell axis
+    if len(axes) == 1:
+        binned_ell = binned_ell[0]
+        binned_lower = binned_lower[0]
+        binned_upper = binned_upper[0]
+        binned_weight = binned_weight[0]
 
     # construct the result
     return Result(
-        out,
-        ell=ell,
-        axis=axis,
-        lower=bins[:-1],
-        upper=bins[1:],
-        weight=wb,
+        result,
+        ell=binned_ell,
+        axis=axes,
+        lower=binned_lower,
+        upper=binned_upper,
+        weight=binned_weight,
     )

--- a/heracles/result.py
+++ b/heracles/result.py
@@ -169,7 +169,7 @@ def binned(result, bins, weight=None):
     dt = np.dtype(float, metadata=md)
 
     # make a copy of the array to apply the binning
-    result = np.asarray(result, dtype=dt, copy=True)
+    out = np.asarray(result, dtype=dt, copy=True)
 
     # this will hold the binned ells and weigths
     binned_ell: tuple[NDArray[Any], ...] | NDArray[Any] = ()
@@ -199,10 +199,10 @@ def binned(result, bins, weight=None):
         for before in np.ndindex(shape[:axis]):
             for after in np.ndindex(shape[axis + 1 :]):
                 k = (*before, slice(None), *after)
-                tmp[k] = norm(np.bincount(index, w * result[k], m)[1:m], wb)
+                tmp[k] = norm(np.bincount(index, w * out[k], m)[1:m], wb)
 
         # array is now binned over axis
-        result = tmp
+        out = tmp
 
         # store outputs
         binned_ell += (ellb,)
@@ -221,7 +221,7 @@ def binned(result, bins, weight=None):
 
     # construct the result
     return Result(
-        result,
+        out,
         ell=binned_ell,
         axis=axes,
         lower=binned_lower,

--- a/heracles/result.py
+++ b/heracles/result.py
@@ -136,19 +136,21 @@ def binned(result, bins, weight=None):
 
     # combine weights of result with weights from string or given array
     weights = []
-    for ell, w in zip(ells, get_result_array(result, "weight")):
-        if weight is None:
+    if not isinstance(weight, tuple):
+        weight = (weight,) * len(axes)
+    for ell, ww, w in zip(ells, weight, get_result_array(result, "weight")):
+        if ww is None:
             pass
-        elif isinstance(weight, str):
-            if weight == "l(l+1)":
+        elif isinstance(ww, str):
+            if ww == "l(l+1)":
                 w = ell * (ell + 1) * w
-            elif weight == "2l+1":
+            elif ww == "2l+1":
                 w = (2 * ell + 1) * w
             else:
-                msg = f"unknown weights string: {weight}"
+                msg = f"unknown weights string: {ww}"
                 raise ValueError(msg)
         else:
-            w = weight[: w.size] * w
+            w = ww[: w.size] * w
         weights.append(w)
 
     # normalise bins into a tuple if a single set is given
@@ -190,11 +192,10 @@ def binned(result, bins, weight=None):
         ellb = norm(np.bincount(index, w * ell, m)[1:m], wb)
 
         # output shape, axis is turned into size m
-        shape = result.shape[:axis] + (m - 1,) + result.shape[axis + 1 :]
+        shape = out.shape[:axis] + (m - 1,) + out.shape[axis + 1 :]
 
         # create an empty binned output array
         tmp = np.empty(shape, dtype=dt)
-
         # compute the binned result axis by axis
         for before in np.ndindex(shape[:axis]):
             for after in np.ndindex(shape[axis + 1 :]):

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -86,7 +86,8 @@ def test_result_2d(rng):
 
 
 @pytest.mark.parametrize("weight", [None, "l(l+1)", "2l+1", "<rand>"])
-@pytest.mark.parametrize("ndim,axis", [(1, 0), (2, 0), (3, 1)])
+# cl['POS', 'POS'], mms['POS', 'POS'], cl['POS', 'SHE'], mms['SHE', 'SHE'], cl['SHE', 'SHE'] 
+@pytest.mark.parametrize("ndim,axis", [(1, 0), (2, 0), (2, 1), (3, 1), (3, 2)])
 def test_binned(ndim, axis, weight, rng):
     shape = rng.integers(1, 100, ndim)
     lmax = shape[axis] - 1
@@ -136,6 +137,85 @@ def test_binned(ndim, axis, weight, rng):
     np.testing.assert_array_almost_equal(result.ell, binned_ell)
     np.testing.assert_array_equal(result.lower, bins[:-1])
     np.testing.assert_array_equal(result.upper, bins[1:])
+    np.testing.assert_array_almost_equal(result.weight, binned_weight)
+
+@pytest.mark.parametrize("weight", [None]) #"l(l+1)", "2l+1", "<rand>"])
+@pytest.mark.parametrize("ndim,axis", [(2, (0, 1)), (4, (2, 3)), (6, (4, 5))])
+def test_binned_2D(ndim, axis, weight, rng):
+    shape = rng.integers(1, 100, ndim)
+    ax1, ax2 = axis
+    lmax1 = shape[ax1] - 1
+    lmax2 = shape[ax2] - 1
+
+    data = heracles.Result(rng.standard_normal(shape), axis=axis)
+
+    nbins1 = rng.integers(1, 10)
+    nbins2 = rng.integers(1, 20)
+    bins1 = rng.integers(1, lmax1 + 1, nbins1, endpoint=True)
+    bins2 = rng.integers(1, lmax2 + 1, nbins2, endpoint=True)
+    bins1.sort()
+    bins2.sort()
+    bins = (bins1, bins2)
+
+    if weight == "<rand>":
+        w1 = rng.random(lmax1 + 1)
+        w2 = rng.random(lmax2 + 1)
+        weight = (w1, w2)
+
+    result = heracles.binned(data, bins1) #, weight)
+    print(bins1)
+    print(data.shape, result.shape)
+
+    ell1 = np.arange(lmax1 + 1)
+    ell2 = np.arange(lmax2 + 1)
+    ell = (ell1, ell2)
+
+    if weight is None:
+        w = (np.ones_like(ell1), np.ones_like(ell2))
+    elif isinstance(weight, str):
+        if weight == "l(l+1)":
+            w = (ell1 * (ell1 + 1), ell2 * (ell2 + 1))
+        elif weight == "2l+1":
+            w = (2 * ell1 + 1, 2 * ell2 + 1)
+        else:
+            raise ValueError(weight)
+    else:
+        w = weight
+
+    out_shape = (*shape[:axis], nbins1 - 1, nbins2 - 1, *shape[axis + 1 :])
+
+    binned_data = np.zeros(out_shape)
+    binned_ell1 = np.zeros(nbins1 - 1)
+    binned_ell2 = np.zeros(nbins2 - 1)
+    binned_w1 = np.zeros(nbins1 - 1)
+    binned_w2 = np.zeros(nbins2 - 1)
+    for i, (a, b) in enumerate(zip(bins1, bins1[1:])):
+        inbin = (a <= ell1) & (ell1 < b)
+        if not np.any(inbin):
+            continue
+        binned_ell1[i] = np.average(ell1[inbin], weights=w[0][inbin])
+        for j in np.ndindex(*shape[:ax1]):
+            for k in np.ndindex(*shape[ax1 + 1 :]):
+                data_inbin = data[(*j, inbin, *k)]
+                binned_data[(*j, i, *k)] = np.average(data_inbin, weights=w[0][inbin])
+        binned_w1[i] = w[0][inbin].sum()
+    for i, (a, b) in enumerate(zip(bins2, bins2[1:])):
+        inbin = (a <= ell2) & (ell2 < b)
+        if not np.any(inbin):
+            continue
+        binned_ell2[i] = np.average(ell2[inbin], weights=w[1][inbin])
+        for j in np.ndindex(*shape[:ax1]):
+            for k in np.ndindex(*shape[ax1 + 1 :]):
+                data_inbin = data[(*j, inbin, *k)]
+                binned_data[(*j, i, *k)] = np.average(data_inbin, weights=w[1][inbin])
+        binned_w2[i] = w[1][inbin].sum()
+    binned_ell = (binned_ell1, binned_ell2)
+    binned_weight = (binned_w1, binned_w2)
+
+    np.testing.assert_array_almost_equal(result, binned_data)
+    np.testing.assert_array_almost_equal(result.ell, binned_ell)
+    np.testing.assert_array_equal(result.lower, (bins[1][:-1], bins[1][:-1]))
+    np.testing.assert_array_equal(result.upper, (bins[0][1:], bins[1][1:]))
     np.testing.assert_array_almost_equal(result.weight, binned_weight)
 
 


### PR DESCRIPTION
Implements the binning for `Result` instances with more than one $\ell$-axis.

If there is a single axis to bin, the binned output will have a single array for `.ell`, `.weight`, etc. Otherwise, it will have a tuple matching the size of `.axis`.

Opening as draft because the new multi-axis binning needs comprehensive tests for all situations we are going to encounter.

Closes: #227