### PR TITLE
gh-278: add helper function for building jackknife maps

### DIFF
--- a/heracles/dices/__init__.py
+++ b/heracles/dices/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "jackknife_fsky",
     "jackknife_bias",
     "correct_bias",
+    "jackknife_maps",
     "jackknife_covariance",
     "debias_covariance",
     "delete2_correction",
@@ -45,6 +46,7 @@ __all__ = [
 
 from .jackknife import (
     jackknife_cls,
+    jackknife_maps,
     jackknife_fsky,
     jackknife_bias,
     correct_bias,


### PR DESCRIPTION
Adds a new `jackknife_maps()` helper function for producing maps with jackknife regions removed.

Closes: #278