### PR TITLE
gh-406: support newer scipy versions

### DIFF
--- a/heracles/transforms.py
+++ b/heracles/transforms.py
@@ -1,18 +1,5 @@
 import numpy as np
-
-try:
-    from scipy.special import lpn as legendrep
-except ImportError:
-    # scipy > 1.15
-    from scipy.special import legendre_p_all
-
-    def legendrep(n, z):
-        """
-        Legendre function of the first kind. Compatibility function for
-        ``scipy.special.lpn()``.
-        """
-        return legendre_p_all(n, z, diff_n=1)
-
+from scipy.special import legendre_p_all
 
 try:
     from copy import replace
@@ -57,7 +44,7 @@ def legendre_funcs(lmax, x, m=(0, 2), lfacs=None, lfacs2=None, lrootfacs=None):
     :return: :math:`(P,P'),(d_{11},d_{-1,1}), (d_{20}, d_{22}, d_{2,-2})` as requested, where P starts
              at :math:`\ell=0`, but spin functions start at :math:`\ell=\ell_{\rm min}`
     """
-    allP, alldP = legendrep(lmax, x)
+    allP, alldP = legendre_p_all(lmax, x, diff_n=1)
     # Polarization functions all start at L=2
     fac1 = 1 - x
     fac2 = 1 + x

--- a/heracles/transforms.py
+++ b/heracles/transforms.py
@@ -1,5 +1,10 @@
-from scipy.special import lpn as legendrep
 import numpy as np
+
+try:
+    from scipy.special import lpn as legendrep
+except ImportError:
+    # scipy > 1.15
+    from scipy.special import legendre_p_all as legendrep
 
 try:
     from copy import replace

--- a/heracles/transforms.py
+++ b/heracles/transforms.py
@@ -1,5 +1,18 @@
 import numpy as np
-from scipy.special import legendre_p_all
+
+try:
+    from scipy.special import legendre_p_all
+except ImportError:
+    # old scipy
+    from scipy.special import lpn
+
+    def legendre_p_all(n, z, *, diff_n=0):
+        """
+        All Legendre polynomials of the first kind up to the specified degree n.
+        """
+        assert diff_n == 1, "only diff_n=1 is supported"
+        return lpn(n, z)
+
 
 try:
     from copy import replace

--- a/heracles/transforms.py
+++ b/heracles/transforms.py
@@ -4,7 +4,15 @@ try:
     from scipy.special import lpn as legendrep
 except ImportError:
     # scipy > 1.15
-    from scipy.special import legendre_p_all as legendrep
+    from scipy.special import legendre_p_all
+
+    def legendrep(n, z):
+        """
+        Legendre function of the first kind. Compatibility function for
+        ``scipy.special.lpn()``.
+        """
+        return legendre_p_all(n, z, diff_n=1)
+
 
 try:
     from copy import replace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "healpy",
     "numba <= 0.61.0",
     "numpy",
-    "scipy <= 1.15",
+    "scipy",
 ]
 description = "Harmonic-space statistics on the sphere"
 dynamic = [


### PR DESCRIPTION
Add support for newer scipy versions by importing [`scipy.special.legendre_p_all()`](https://docs.scipy.org/doc/scipy-1.17.0/reference/generated/scipy.special.legendre_p_all.html) as a drop-in replacement of the deprecated `lpn`.

Closes: #406