### PR TITLE
gh-413: hotfix

### DIFF
--- a/heracles/mapping.py
+++ b/heracles/mapping.py
@@ -151,7 +151,7 @@ def transform(
     for (k, i), m in data.items():
         current += 1
         progress.update(current, total)
-
+        m = getattr(m, "array", m)
         with progress.task(f"({k}, {i})"):
             try:
                 field = fields[k]


### PR DESCRIPTION
For reasons beyond me we need to make sure that during transform we extract the array of the maps' fields.
Fixes:  #413 